### PR TITLE
[codex] Document revival roadmap and shared memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-# Cline/Roo specific - IDE and tool configuration
+# Legacy Cline/Roo specific IDE and tool configuration
 .clinerules-architect
 .clinerules-ask
 .clinerules-code
-memory-bank/
+memory-bank/*.code-workspace
 
 # Dependency directories
 node_modules/
@@ -105,6 +105,5 @@ locallama.bk1
 mcp-chat.bk1
 lm-studio-models.json
 chats.db
-CLAUDE.md
 package-lock.json
 job-results.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,96 @@
+# AGENTS.md
+
+This file is the shared operating guide for Codex, Claude Code, Claw Code, Cursor, Copilot Agent mode, and any other coding agent working in this repository.
+
+## Project Direction
+
+LocalLama MCP is being revived as a local-first, provider-neutral MCP server for coding-agent workflows. The goal is no longer to target Cline or Roo Code specifically. The server should help modern agents route coding work across local models, free/low-cost remote models, and paid frontier models using measured cost, latency, quality, context capacity, and task fit.
+
+Use the roadmap in `docs/ROADMAP.md` as the source of truth for modernization work.
+
+## Shared Memory
+
+This repo uses `memory-bank/` as multi-author project memory. Before planning non-trivial work, read:
+
+- `memory-bank/README.md`
+- `memory-bank/activeContext.md`
+- `memory-bank/progress.md`
+- `memory-bank/decisionLog.md`
+
+After meaningful work, append or update memory with:
+
+- What changed
+- Why it changed
+- Verification performed
+- Known follow-ups or blockers
+
+Do not rewrite another contributor's historical notes unless the user explicitly asks. Add dated entries instead.
+
+## Development Commands
+
+### Build and Run
+
+- `npm run build` - Compile TypeScript to JavaScript and copy `lock-file.js` to `dist/`
+- `npm start` - Start the MCP server after building
+- `npm run dev` - Development mode with TypeScript watching and auto-restart
+
+Current known issue: `npm run build` uses Unix `cp`, so it fails on native Windows after TypeScript compilation. `npx tsc --project tsconfig.json --noEmit` currently type-checks successfully.
+
+### Testing
+
+- `npm test` - Run all tests
+- `npm test:watch` - Run tests in watch mode
+- Tests live in `test/` and mirror `src/`
+
+### Code Quality
+
+- `npm run lint` - Run ESLint on TypeScript files
+- `npm run lint:fix` - Run ESLint with auto-fix
+
+Current known issue: lint references `eslint-plugin-import`, which is not installed.
+
+### Benchmarking
+
+- `npm run benchmark` - Intended basic benchmark command
+- `npm run benchmark:comprehensive` - Intended comprehensive benchmark command
+
+Current known issue: these scripts reference a missing `run-benchmarks.js`.
+
+## Architecture Overview
+
+The project is a TypeScript ESM MCP server built around these areas:
+
+- `src/index.ts` - MCP server entry point, process lifecycle, lock-file handling, tool routing
+- `src/modules/api-integration/` - MCP tool definitions, resources, routing adapters, OpenRouter integration
+- `src/modules/decision-engine/` - task analysis, model selection, task coordination, code evaluation
+- `src/modules/cost-monitor/` - token accounting, cost estimation, code search/cache helpers
+- `src/modules/benchmark/` - benchmark execution, scoring, summaries, storage
+- `src/modules/lm-studio/`, `src/modules/ollama/`, `src/modules/openrouter/` - provider integrations
+
+## Modernization Priorities
+
+1. Restore reliable local development: cross-platform build, lint dependencies, tests, benchmark entrypoints.
+2. Make MCP responses and schemas match current MCP expectations, including structured tool content where appropriate.
+3. Replace simulated paid benchmarks with real provider adapters behind a common interface.
+4. Replace stale hardcoded model fallbacks with discovered capabilities and benchmark history.
+5. Move prompt understanding toward structured output and validated parsing.
+6. Update docs and examples for current agent clients: Codex, Claude Code, Claw Code, Cursor, Copilot Agent mode, and generic MCP clients.
+
+## Coding Guidelines
+
+- Prefer existing module boundaries and patterns before adding new abstractions.
+- Keep changes scoped. Do not refactor unrelated code while fixing docs or one subsystem.
+- Use TypeScript types for contracts between routing, benchmarking, and provider modules.
+- Prefer structured parsing over regex when model output is expected to be machine-readable.
+- Keep provider-specific logic behind provider modules; do not scatter model-name checks through the decision engine.
+- For benchmark changes, prefer executable scoring: apply patches, run tests, and record results. Heuristic quality scoring should be secondary metadata, not the main pass/fail signal.
+
+## Safety
+
+- Treat MCP tools as model-controlled surfaces. Avoid adding tools that mutate files, run commands, or call paid APIs without clear user/client approval paths.
+- Do not commit API keys, local model inventories with secrets, logs containing tokens, or private benchmark outputs.
+- Be careful with `memory-bank/`: it is project coordination state, not a scratchpad for secrets.
+
+## Python Dependencies
+
+Retriv code search requires Python 3.8+ and dependencies from `requirements.txt`, including `retriv`, `numpy`, `scikit-learn`, and `scipy`. Prefer a virtual environment and configure `PYTHON_PATH`/`RETRIV_PYTHON_PATH` in `.env`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md
+
+Claude Code should use `AGENTS.md` as the primary project guide.
+
+Before starting non-trivial work, read:
+
+- `AGENTS.md`
+- `docs/ROADMAP.md`
+- `memory-bank/README.md`
+- `memory-bank/activeContext.md`
+- `memory-bank/progress.md`
+- `memory-bank/decisionLog.md`
+
+When configuring this MCP server for Claude Code, prefer project-scoped MCP config when sharing with collaborators and keep secrets in environment variables. Append work notes to `memory-bank/` rather than replacing prior contributor context.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,28 @@
-# LocaLLama MCP Server (Testing Branch)
+# LocalLama MCP Server
 
-An MCP Server that works with Roo Code or Cline.Bot (Currently Untested with Claude Desktop or CoPilot MCP VS Code Extension) to optimize costs by intelligently routing coding tasks between local LLMs and paid APIs. Lot's of broken implementation in this.
+LocalLama MCP is a local-first, provider-neutral Model Context Protocol server for modern coding-agent workflows. It is being revived to support current MCP-capable tools such as Codex, Claude Code, Claw Code, Cursor, GitHub Copilot Agent mode, and generic MCP clients.
+
+The project routes coding work across local models, free or low-cost remote models, and paid frontier models using cost, latency, context capacity, benchmark history, and task fit. It is no longer designed around Cline or Roo Code as primary clients.
+
+> Revival status: this repository has useful architecture, but several development commands and benchmark paths are stale. See `docs/ROADMAP.md` for the active modernization plan.
 
 ## Overview
 
-LocalLama MCP Server is designed to reduce token usage and costs by dynamically deciding whether to offload a coding task to a local, less capable instruct LLM (e.g., LM Studio, Ollama) versus using a paid API. Version 1.7.0 introduces smart code task analysis, advanced dependency mapping, and intelligent task decomposition features.
+LocalLama MCP Server is designed to reduce token usage and costs without giving up quality. It dynamically decides whether a coding task should run on a local model, a free or low-cost remote model, or a paid frontier model. The long-term direction is to make those decisions from measured provider capabilities and executable benchmark results instead of hardcoded model assumptions.
+
+## Current Baseline
+
+- `npx tsc --project tsconfig.json --noEmit` succeeds.
+- `npm run build` currently fails on native Windows because the package script uses Unix `cp`.
+- `npm run lint` currently fails because `eslint-plugin-import` is referenced but not installed.
+- `npm run benchmark` and `npm run benchmark:comprehensive` currently reference a missing `run-benchmarks.js`.
+
+## Project Memory and Roadmap
+
+- `AGENTS.md` is the shared operating guide for coding agents.
+- `CLAUDE.md` points Claude Code at the same shared guidance.
+- `memory-bank/` contains multi-author project memory.
+- `docs/ROADMAP.md` is the modernization roadmap and implementation plan.
 
 ## Key Components
 
@@ -263,9 +281,9 @@ PYTHON_DETECT_VENV=true
   - `LOCK_FILE_CHECK_ACTIVE_PROCESS`: Verify if processes in lock files are still running
   - `REMOVE_STALE_LOCK_FILES`: Automatically clean up stale lock files from crashed processes
 
-### Environment Variables for Cline.Bot and Roo Code
+### Environment Variables for MCP Clients
 
-When integrating with Cline.Bot or Roo Code, you can pass these environment variables directly:
+When integrating with Codex, Claude Code, Claw Code, Cursor, GitHub Copilot Agent mode, or another MCP-capable client, pass these environment variables through that client's MCP server configuration:
 
 - For **simple configuration**: Use the basic env variables in your MCP setup
 - For **advanced routing**: Configure thresholds to fine-tune when local vs. cloud models are used
@@ -352,16 +370,18 @@ The server now provides job tracking resources:
 - **Job Progress**: Track the progress of a specific job via `locallama://jobs/progress/{jobId}`
 - **Job Cancellation**: Cancel a running job using the `cancel_job` tool
 
-### Using with Cline.Bot
+### Using with Modern MCP Clients
 
-To use this MCP Server with Cline.Bot, add it to your Cline MCP settings:
+Build the server, then configure your MCP client to launch `node dist/index.js` with the environment variables relevant to your local setup.
+
+Generic stdio MCP configuration:
 
 ```json
 {
   "mcpServers": {
     "locallama": {
       "command": "node",
-      "args": ["/path/to/locallama-mcp"],
+      "args": ["/path/to/locallama-mcp/dist/index.js"],
       "env": {
         "LM_STUDIO_ENDPOINT": "http://localhost:1234/v1",
         "OLLAMA_ENDPOINT": "http://localhost:11434/api",
@@ -379,7 +399,9 @@ To use this MCP Server with Cline.Bot, add it to your Cline MCP settings:
 }
 ```
 
-Once configured, you can use the MCP tools in Cline.Bot:
+Claude Code project-scoped configuration can use the same server shape in `.mcp.json`. Codex users should add this server through Codex MCP configuration or the Codex CLI, using the same command, args, and environment values.
+
+Once configured, the MCP client can discover and use tools such as:
 
 - `get_free_models`: Retrieve the list of free models from OpenRouter
 - `clear_openrouter_tracking`: Force a fresh update of OpenRouter models if you encounter issues
@@ -389,7 +411,7 @@ Once configured, you can use the MCP tools in Cline.Bot:
 - `retriv_init`: Initialize and configure Retriv for code search and indexing
 - `cancel_job`: Cancel a running job to prevent runaway costs
 
-Example usage in Cline.Bot:
+Example tool call:
 
 ```
 /use_mcp_tool locallama clear_openrouter_tracking {}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,142 @@
+# LocalLama MCP Revival Roadmap
+
+Last updated: 2026-04-24
+
+## Purpose
+
+LocalLama MCP is being revived as a local-first, provider-neutral MCP server for modern coding agents. The project should help agents choose between local models, free or low-cost remote models, and paid frontier models using measured task fit, cost, latency, context capacity, reliability, and benchmark history.
+
+The project should support current MCP-capable tools such as Codex, Claude Code, Claw Code, Cursor, GitHub Copilot Agent mode, and generic MCP clients. It should not be designed around Cline or Roo Code as primary clients.
+
+## Current Baseline
+
+- TypeScript source type-checks with `npx tsc --project tsconfig.json --noEmit`.
+- `npm run build` fails on native Windows after TypeScript compilation because it uses Unix `cp`.
+- `npm run lint` fails because `eslint-plugin-import` is referenced but not installed.
+- `npm run benchmark` and `npm run benchmark:comprehensive` reference missing `run-benchmarks.js`.
+- Tool definitions include duplication and some stale descriptions.
+- Benchmarking still contains simulated paid-model paths.
+- Routing still relies on hardcoded model-name heuristics and stale fallback models.
+- Documentation still contains old Cline/Roo positioning in several places.
+
+## Roadmap
+
+### Phase 0: Documentation and Shared Memory
+
+Status: in progress
+
+- Update `AGENTS.md` as the primary agent-neutral operating guide.
+- Keep `CLAUDE.md` as a thin Claude Code pointer to shared docs.
+- Add a multi-author memory convention under `memory-bank/`.
+- Add this roadmap as the implementation source of truth.
+- Update README positioning away from Cline/Roo-specific language.
+
+Exit criteria:
+
+- A new contributor can identify current goals, known broken commands, and where to leave project state.
+
+### Phase 1: Restore Developer Workflow
+
+Status: pending
+
+- Make `npm run build` cross-platform by replacing `cp` with a Node script or `cpy`-style package.
+- Fix lint by installing `eslint-plugin-import` or removing the unused import rule.
+- Restore or remove benchmark npm scripts so package commands are truthful.
+- Run `npm test` after build script repair.
+- Document any environment-specific requirements for Windows, WSL, macOS, and Linux.
+
+Exit criteria:
+
+- `npm run build`, `npm run lint`, and `npm test` complete or fail only for documented external-service reasons.
+
+### Phase 2: MCP Surface Modernization
+
+Status: pending
+
+- Audit tool result shapes against current MCP content expectations.
+- Remove duplicate tool definitions in `api-integration/tool-definition`.
+- Add clearer tool descriptions for model-controlled agent use.
+- Split read-only tools from tools that execute work, cancel jobs, mutate benchmark state, or call paid APIs.
+- Consider optional Streamable HTTP transport while preserving stdio.
+- Add client setup examples for Codex, Claude Code, Cursor, Copilot Agent mode, and generic MCP clients.
+
+Exit criteria:
+
+- MCP tool discovery is concise, client-neutral, and safe for modern agents.
+
+### Phase 3: Provider Abstraction
+
+Status: pending
+
+- Define one provider interface for model listing, chat/completion calls, token usage, pricing, and capability metadata.
+- Implement adapters for LM Studio, Ollama, OpenRouter, and at least one direct paid provider.
+- Keep provider-specific quirks inside provider modules.
+- Replace hardcoded stale fallback models with configured defaults and discovered capabilities.
+- Track model metadata: context window, cost, tool support, structured output support, reasoning controls, latency, throughput, and local resource cost where available.
+
+Exit criteria:
+
+- Routing and benchmarking consume a common provider contract instead of scattered provider checks.
+
+### Phase 4: Benchmarking Rebuild
+
+Status: pending
+
+- Replace simulated paid benchmarks with real provider calls or explicitly labeled dry-run mode.
+- Make benchmark results reproducible and structured.
+- Add benchmark suites by task class:
+  - Simple function/code generation
+  - Multi-file code editing
+  - Bug fix with tests
+  - Refactor with behavior preservation
+  - Documentation and explanation
+- Prefer executable scoring over text heuristics: apply diffs, run tests, and record pass/fail.
+- Keep heuristic quality scores as supplemental metadata only.
+- Add cost and latency reporting per successful task.
+
+Exit criteria:
+
+- Benchmark output can be trusted by the decision engine for model routing.
+
+### Phase 5: Task Understanding and Routing
+
+Status: pending
+
+- Replace regex-heavy prompt parsing with validated structured outputs where supported.
+- Add task classification fields: task type, risk level, expected artifact, relevant files, test strategy, context needs, latency tolerance, and cost ceiling.
+- Route based on measured performance and capabilities before model-name heuristics.
+- Add cold-start routing rules for unknown models.
+- Track routing decisions and outcomes for later calibration.
+
+Exit criteria:
+
+- The decision engine can explain why a model was selected using current evidence, not just hardcoded names.
+
+### Phase 6: Documentation, Examples, and Release Prep
+
+Status: pending
+
+- Rewrite README into a current quickstart plus architecture overview.
+- Add `docs/CONFIGURATION.md`, `docs/MCP_CLIENTS.md`, and `docs/BENCHMARKING.md` if the README grows too large.
+- Update `.env.example` with current provider and benchmark settings.
+- Add troubleshooting for local model servers, OpenRouter failures, Python/Retriv setup, and lock-file issues.
+- Decide whether old Roo-specific files should remain, be archived, or be removed.
+
+Exit criteria:
+
+- A user can install, configure, run, benchmark, and connect the MCP server from current docs.
+
+## Open Design Decisions
+
+- Whether to keep Retriv or move code search toward a simpler built-in index plus optional semantic backends.
+- Whether to support only stdio initially or add Streamable HTTP during MCP modernization.
+- Which direct paid provider should be implemented first.
+- How much benchmark data should be committed versus treated as local generated output.
+- Whether old `.roomodes` and `.rooignore` files are useful historical artifacts or should be removed.
+
+## Working Agreement
+
+- Keep `AGENTS.md` and this roadmap aligned when project direction changes.
+- Append meaningful decisions to `memory-bank/decisionLog.md`.
+- Update `memory-bank/progress.md` when finishing a roadmap item.
+- Update `memory-bank/activeContext.md` when the current focus changes.

--- a/memory-bank/README.md
+++ b/memory-bank/README.md
@@ -1,0 +1,38 @@
+# Memory Bank
+
+This directory is shared project memory for humans and coding agents. It exists so every contributor can quickly recover the current project direction, decisions, and unfinished work without relying on one chat transcript.
+
+## Files
+
+- `activeContext.md` - current focus, working assumptions, and immediate next work
+- `progress.md` - completed work and roadmap progress
+- `decisionLog.md` - dated decisions and rationale
+- `productContext.md` - durable product direction and goals
+- `sessionLog.md` - append-only notes from individual work sessions
+
+## Multi-Author Rules
+
+- Read `AGENTS.md`, `docs/ROADMAP.md`, and this README before non-trivial work.
+- Prefer appending dated entries over rewriting history.
+- Keep entries factual: what changed, why, verification, and next steps.
+- Use absolute dates such as `2026-04-24`, not "today" or "yesterday".
+- Do not store secrets, API keys, private prompts, or sensitive logs here.
+- If a prior note is wrong, add a correction with a date and rationale instead of silently deleting it.
+
+## Session Entry Template
+
+```md
+## 2026-04-24 - Short Title
+
+Author: name or agent/tool
+
+Summary:
+- What changed
+- Why it changed
+
+Verification:
+- Commands run or checks performed
+
+Follow-ups:
+- Remaining work, blockers, or open questions
+```

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,0 +1,35 @@
+# Active Context
+
+Last updated: 2026-04-24
+
+## Current Focus
+
+The project is being revived and repositioned away from Cline/Roo-specific usage. The new direction is a local-first, provider-neutral MCP server for modern coding agents such as Codex, Claude Code, Claw Code, Cursor, GitHub Copilot Agent mode, and generic MCP clients.
+
+The current workstream is documentation and shared project memory. `docs/ROADMAP.md` is now the modernization source of truth.
+
+## Baseline Findings
+
+- `npx tsc --project tsconfig.json --noEmit` succeeds.
+- `npm run build` fails on native Windows after TypeScript compilation because the script uses Unix `cp`.
+- `npm run lint` fails because `eslint-plugin-import` is referenced by `eslint.config.js` but is not installed.
+- `npm run benchmark` and `npm run benchmark:comprehensive` reference missing `run-benchmarks.js`.
+- Benchmarking still includes simulated paid-model paths.
+- Routing still includes stale hardcoded model fallbacks and model-name heuristics.
+- README opening and MCP client setup sections now use current agent-neutral positioning.
+
+## Current Goals
+
+- Finish documentation refresh.
+- Repair the local developer workflow.
+- Modernize MCP tool definitions and result shapes.
+- Rebuild provider and benchmark layers around real provider adapters and executable scoring.
+- Move routing from hardcoded model names toward discovered capabilities and benchmark history.
+
+## Open Questions
+
+- Should the project keep Retriv as the main code search backend, or make it optional behind a simpler built-in index?
+- Should Streamable HTTP support be added during the MCP modernization phase or after stdio is cleaned up?
+- Which direct paid provider should be implemented first alongside OpenRouter?
+- Should old Roo-specific files such as `.roomodes` and `.rooignore` be archived or removed?
+- How much generated benchmark data should stay in the repository?

--- a/memory-bank/decisionLog.md
+++ b/memory-bank/decisionLog.md
@@ -1,0 +1,336 @@
+# Decision Log
+
+This document tracks key architectural and technical decisions made throughout the project, along with their rationale.
+
+## Table of Contents
+
+1. [Free Model Benchmarking Improvements (2/27/2025)](#2272025---free-model-benchmarking-improvements)
+2. [Code Quality Assessment Enhancement (2/27/2025)](#2272025---code-quality-assessment-enhancement)
+3. [Fair Model Selection Approach (2/27/2025)](#2272025---fair-model-selection-approach)
+4. [OpenRouter Free Model Testing (2/26/2025)](#2262025---openrouter-free-model-testing)
+5. [TypeScript Error Fixes in API Integration Tools (2/26/2025)](#2262025---typescript-error-fixes-in-api-integration-tools)
+6. [OpenRouter Integration (2/26/2025)](#2262025---openrouter-integration)
+7. [Security and Organization Improvements (2/26/2025)](#2262025---security-and-organization-improvements)
+8. [Version Management Policy (2/26/2025)](#2262025---version-management-policy)
+9. [OpenRouter Resources Exposure (2/26/2025)](#2262025---openrouter-resources-exposure)
+10. [Code Cleanup and Bug Fixes (2/26/2025)](#2262025---code-cleanup-and-bug-fixes)
+11. [Preemptive Decision Framework (2/26/2025)](#2262025---preemptive-decision-framework-implementation)
+12. [Comprehensive Benchmark Execution (2/26/2025)](#2262025---comprehensive-benchmark-execution)
+13. [User-Driven Model Selection (2/26/2025)](#2262025---user-driven-model-selection-and-configuration)
+14. [Comprehensive Model Benchmarking (2/26/2025)](#2262025---comprehensive-model-benchmarking-approach)
+15. [Benchmark Task Selection (2/26/2025)](#2262025---benchmark-task-selection-strategy)
+16. [Benchmarking System Implementation (2/26/2025)](#2262025---benchmarking-system-implementation)
+17. [Unit Testing Strategy (2/25/2025)](#2252025---unit-testing-strategy)
+18. [Model Context Window Tracking (2/25/2025)](#2252025---model-context-window-tracking)
+19. [Decision Engine Optimization (2/25/2025)](#2252025---decision-engine-optimization)
+20. [API Integration Approach (2/25/2025)](#2252025---api-integration-approach)
+21. [Decision Engine Design (2/25/2025)](#2252025---decision-engine-design)
+22. [Project Structure and Technology (2/25/2025)](#2252025---project-structure-and-technology-choices)
+23. [Begin Implementation Phase (2/25/2025)](#2252025---begin-implementation-phase)
+24. [Memory Bank Initialization (2/25/2025)](#2252025---memory-bank-initialization)
+
+## 2/27/2025 - Free Model Benchmarking Improvements
+
+**Context:** The initial implementation of free model benchmarking had several limitations: it only tested a small number of models, didn't verify if the code actually worked, and prioritized well-known providers over potentially better but lesser-known models.
+
+**Decision:** Enhance the benchmarkFreeModels method with better code quality assessment, working code verification, and a fair model selection approach that ensures all free models get benchmarked eventually.
+
+**Rationale:**
+- Benchmarking only a few models might miss high-quality free models from lesser-known providers
+- Simply checking if a response contains code isn't sufficient; we need to verify if the code actually works
+- A more sophisticated quality assessment can better differentiate between models
+- Rate limiting protection is necessary to avoid API bans when benchmarking multiple models
+- Automatically checking for unbenchmarked models ensures we continuously improve our model database
+
+**Implementation:**
+- Added code checks to verify if models produce working code (e.g., factorial function actually calculates factorials)
+- Implemented a more sophisticated evaluateQuality method with checks for code blocks, programming constructs, explanations, and comments
+- Created a benchmark-free-models.js script to run the benchmarking process
+- Added rate limiting protection with delays between API calls (5 seconds between tasks, 10 seconds between models)
+- Updated the decision engine to automatically check for unbenchmarked free models during initialization
+- Added environment variable support (MAX_MODELS_TO_BENCHMARK) to control how many models are benchmarked per run
+
+## 2/27/2025 - Code Quality Assessment Enhancement
+
+**Context:** The existing evaluateQuality method in the openRouterModule was too simplistic, only checking for the presence of code and not evaluating its quality or correctness.
+
+**Decision:** Implement a more sophisticated code quality assessment method that evaluates multiple aspects of code quality and provides a more accurate quality score.
+
+**Rationale:**
+- Simply checking if a response contains code isn't sufficient for evaluating model performance
+- Different types of tasks (coding vs. non-coding) require different evaluation criteria
+- Code quality includes factors like proper structure, comments, explanations, and programming constructs
+- A more accurate quality assessment leads to better model selection decisions
+- Penalizing very short responses helps filter out models that don't provide substantial answers
+
+**Implementation:**
+- Enhanced the evaluateQuality method with checks for:
+  - Code blocks (markdown or other formats)
+  - Common programming constructs (return statements, conditionals, loops, imports, function calls)
+  - Explanations of code functionality and complexity
+  - Code comments
+  - Response length relative to task length
+  - Response structure (paragraphs, bullet points, etc.)
+- Implemented different scoring strategies for coding vs. non-coding tasks
+- Added penalties for very short responses
+- Ensured the quality score is normalized between 0 and 1 for consistent comparison
+
+## 2/27/2025 - Fair Model Selection Approach
+
+**Context:** The initial implementation prioritized models from well-known providers (Google, Meta, Mistral, etc.) over potentially better but lesser-known models, which could lead to missing high-quality free models.
+
+**Decision:** Implement a fair model selection approach that ensures all free models get benchmarked eventually, without prioritizing based on provider name.
+
+**Rationale:**
+- Prioritizing well-known providers might miss high-quality free models from lesser-known providers
+- All free models should have a fair chance to demonstrate their capabilities
+- Benchmarking should be based on objective criteria, not provider reputation
+- Once all models have been benchmarked, we can prioritize based on actual performance data
+- This approach ensures we continuously improve our model database with comprehensive data
+
+**Implementation:**
+- Modified the model selection approach to prioritize unbenchmarked models first
+- Added tracking of benchmark counts to identify models with the fewest benchmarks
+- Implemented a system that selects models based on benchmark count rather than provider name
+- Added detailed logging about the model selection process
+- Created a fallback mechanism to ensure we always have models to benchmark
+- Added environment variable support to control how many models are benchmarked per run
+- Implemented provider categorization for better organization of free models in logs
+
+## 2/26/2025 - OpenRouter Free Model Testing
+
+**Context:** After implementing the OpenRouter integration to provide access to free models as a cost-saving option, we needed to test this functionality to ensure it works correctly. We needed to verify that the system can identify free models from OpenRouter, expose them through MCP resources, and consider them in the decision engine when routing tasks.
+
+**Decision:** Create test scripts to verify the OpenRouter free model functionality and test the integration with the decision engine.
+
+**Rationale:**
+- Testing is essential to ensure the OpenRouter integration works as expected
+- Free models can provide significant cost savings for appropriate tasks
+- The decision engine needs to consider OpenRouter models when routing tasks
+- Proper error handling is needed for cases where OpenRouter API is unavailable or no free models are available
+
+**Implementation:**
+- Created test scripts to query OpenRouter for available models
+- Tested the ability to identify free models (those with "free" in their name)
+- Verified that the system can identify and use low-cost models as an alternative when no free models are available
+- Tested the MCP resources for accessing OpenRouter model information
+- Confirmed that the decision engine correctly considers OpenRouter models when routing tasks
+- Identified areas for improvement in error handling and fallback mechanisms
+
+## 2/26/2025 - TypeScript Error Fixes in API Integration Tools
+
+**Context:** During code review, we identified TypeScript errors in the API integration tools.ts file where parameter types were incorrectly defined as strings instead of numbers. These errors needed to be fixed to ensure type safety and proper functionality of the API integration tools.
+
+**Decision:** Fix the TypeScript errors in the API integration tools.ts file by correcting parameter types and adding proper type annotations.
+
+**Rationale:**
+- Type safety is critical for preventing runtime errors and ensuring code reliability
+- Consistent parameter types across the codebase improve maintainability
+- Proper type annotations make the code more self-documenting
+- Clear comments help future developers understand the purpose of each parameter
+- Ensuring the API integration tools function correctly is essential for the overall system
+
+**Implementation:**
+- Corrected parameter types for context_length, expected_output_length, and complexity from string to number
+- Added proper type annotations with comments for clarity (e.g., "// Corrected type")
+- Ensured consistent type handling across all tool implementations
+- Verified the API integration tools functionality is intact with no errors
+- Updated Memory Bank documentation to reflect the fixes
+
+## 2/26/2025 - OpenRouter Integration
+
+**Context:** The project needed to query OpenRouter for free models and add them to the decision framework as a cost-saving possibility. This would allow users to take advantage of free models when available, potentially reducing costs while still providing good results for appropriate tasks.
+
+**Decision:** Implement a comprehensive OpenRouter module that can:
+1. Query OpenRouter for available models
+2. Track free models
+3. Handle errors from OpenRouter
+4. Determine the best prompting strategy for each model
+5. Benchmark prompting strategies
+
+**Rationale:**
+- Free models from OpenRouter can provide significant cost savings
+- Different models may require different prompting strategies for optimal results
+- Error handling is important for reliability, especially with external APIs
+- Benchmarking helps determine the best model and prompting strategy for each task
+- Integrating free models into the decision framework provides more options for cost-sensitive users
+
+**Implementation:**
+- Created a new OpenRouter module with types and implementation
+- Updated cost monitor to include OpenRouter models in available models list
+- Enhanced decision engine to consider free models when making routing decisions
+- Updated benchmark module to support benchmarking OpenRouter models
+- Added API integration tools to expose OpenRouter functionality
+- Used a helper function to check if OpenRouter API key is configured
+- Added error handling for rate limiting and other API errors
+
+## 2/26/2025 - Security and Organization Improvements
+
+**Context:** The project contains sensitive data like API keys and a large number of benchmark result files that needed to be properly managed to ensure security and maintainability.
+
+**Decision:** Implement comprehensive security measures and organization tools to protect sensitive data and improve project structure.
+
+**Rationale:**
+- API keys and other credentials should never be committed to public repositories
+- A well-structured project is easier to maintain and understand
+- Benchmark results provide valuable insights but need to be organized effectively
+- Clear documentation about security practices helps contributors follow best practices
+
+**Implementation:**
+- Enhanced the .gitignore file with more comprehensive patterns to prevent sensitive data from being committed
+- Created a proper .env.example template without actual API keys
+- Added a script (organize-benchmark-results.js) to organize benchmark results into subdirectories
+- Updated README.md with information about benchmark results and security considerations
+- Added new npm scripts for running benchmarks and organizing results
+- Documented security improvements in Memory Bank
+
+## 2/26/2025 - Version Management Policy
+
+**Context:** After completing several major components and features, we needed to establish a clear versioning policy for the project.
+
+**Decision:** Implement a consistent version management approach where the version number is updated with each task completion, following standard semantic versioning rules.
+
+**Rationale:**
+- Regular version updates provide a clear history of project progress
+- Following semantic versioning (MAJOR.MINOR.PATCH) allows for clear communication about the nature of changes:
+  - MAJOR: Breaking changes
+  - MINOR: New features, no breaking changes
+  - PATCH: Bug fixes, no new features or breaking changes
+- Updating the version with each task completion ensures we maintain an accurate record of project evolution
+- Version history helps with tracking when specific features or fixes were implemented
+
+**Implementation:**
+- Updated version from 1.0.0 to 1.2.5 to reflect current project progress
+- Added versioning policy to activeContext.md
+- Will update package.json and package-lock.json version number with each task completion going forward
+- Will document version changes in the Memory Bank
+
+## 2/26/2025 - OpenRouter Resources Exposure
+
+**Context:** After implementing the OpenRouter module to query for free models and integrate them into the decision framework, we needed to expose these resources to MCP clients. This would allow clients to access information about available OpenRouter models, free models, and prompting strategies.
+
+**Decision:** Update the resources.ts file to expose OpenRouter resources and resource templates, and implement handlers for these resources.
+
+**Rationale:**
+- Exposing OpenRouter resources through the MCP server allows clients to access information about available models
+- Resource templates provide a way to access model-specific details and prompting strategies
+- Proper error handling ensures reliability when OpenRouter API is not configured or unavailable
+- Testing the resources ensures they work correctly before deployment
+
+**Implementation:**
+- Added OpenRouter static resources:
+  - locallama://openrouter/models - List of available models from OpenRouter
+  - locallama://openrouter/free-models - List of free models available from OpenRouter
+  - locallama://openrouter/status - Status of the OpenRouter integration
+- Added OpenRouter resource templates:
+  - locallama://openrouter/model/{modelId} - Details about a specific OpenRouter model
+  - locallama://openrouter/prompting-strategy/{modelId} - Prompting strategy for a specific OpenRouter model
+- Updated resource handlers to handle these resources
+- Added proper error handling for cases where OpenRouter API key is not configured
+- Created a test script to verify the functionality of all OpenRouter resources
+- Successfully tested all resources and resource templates
+
+## 2/26/2025 - Code Cleanup and Bug Fixes
+
+**Context:** During code review, we identified an issue in the decision-engine's index.ts file where there was duplicated code causing TypeScript errors. This needed to be fixed to ensure the proper functioning of the decision engine.
+
+**Decision:** Remove the duplicated code in the decision-engine's index.ts file to fix the TypeScript errors.
+
+**Rationale:**
+- Duplicated code can lead to maintenance issues and unexpected behavior
+- TypeScript errors indicate potential runtime issues that could affect the reliability of the decision engine
+- Clean code is essential for maintainability and future development
+- Ensuring the decision engine functions correctly is critical for the overall system
+
+**Implementation:**
+- Identified the duplicated code in the decision-engine's index.ts file
+- Found that the file had a complete implementation of the decisionEngine object that ended at line 652
+- Discovered that starting at line 653, there was duplicated code from the updateModelPerformanceProfiles method, followed by complete duplicates of the preemptiveRouting and routeTask methods
+- Removed the duplicated code, keeping only the properly structured implementation
+- Verified that the file structure was correct with proper implementation of all methods
+- Confirmed that the decision engine functionality remained intact with no errors
+
+## 2/26/2025 - Preemptive Decision Framework Implementation
+
+**Context:** The existing decision engine makes API calls to get cost estimates and available models before making a routing decision, which can add latency. Based on benchmark results, we identified patterns that could enable faster decision-making without these API calls.
+
+**Decision:** Implement a preemptive decision framework that can make routing decisions at task initialization without making API calls.
+
+**Rationale:**
+- API calls to get cost estimates and available models add latency to the decision process
+- Benchmark results show clear patterns in model performance based on task complexity and token count
+- Many routing decisions can be made with high confidence based on these patterns alone
+- Eliminating redundant cost-comparison queries improves system efficiency
+- Users benefit from faster response times for straightforward routing decisions
+
+**Implementation:**
+- Added a preemptiveRouting function to the decision engine that makes decisions based on task characteristics without API calls
+- Defined complexity thresholds (SIMPLE: 0.3, MEDIUM: 0.6, COMPLEX: 0.8) based on benchmark results
+- Defined token thresholds (SMALL: 500, MEDIUM: 2000, LARGE: 8000) for context size categorization
+- Created model performance profiles with data from benchmark results
+- Added a preemptive flag to the route_task tool to optionally use preemptive routing
+- Created a dedicated preemptive_route_task tool for explicit preemptive routing
+- Modified the main routeTask function to first attempt a preemptive decision and only make API calls if confidence is low
+- Updated the API integration tools to expose the new preemptive routing capabilities
+
+## 2/26/2025 - Comprehensive Benchmark Execution
+
+**Context:** After implementing the comprehensive benchmarking system, we needed to run actual benchmarks to evaluate the performance of local LLM models against paid API models.
+
+**Decision:** Execute comprehensive benchmarks using the run-benchmarks.js script with the "comprehensive" mode.
+
+**Rationale:**
+- Running comprehensive benchmarks provides concrete data on model performance
+- Comparing multiple models helps identify the best options for different types of tasks
+- Benchmark results can be used to refine the decision engine's routing logic
+- Understanding the performance characteristics of different models is essential for making informed routing decisions
+
+**Implementation:**
+- Built the project using npm run build
+- Executed comprehensive benchmarking using node run-benchmarks.js comprehensive
+- Benchmarked qwen2.5-coder-3b-instruct against multiple paid models:
+  - gpt-3.5-turbo
+  - gpt-4o
+  - claude-3-sonnet-20240229
+  - gemini-1.5-pro
+  - mistral-large-latest
+- Generated benchmark reports and summary files
+- Analyzed benchmark results showing local model performance:
+  - Average response time: ~7000ms
+  - Success rate: 100%
+  - Quality score: 0.85
+- Identified connection issues with Ollama service that need to be addressed
+- Created benchmark result files for all task types (simple, medium, complex)
+
+## 2/25/2025 - Memory Bank Initialization
+
+**Context:** Project initialization requires a structured approach to documentation and planning.
+
+**Decision:** Implemented a Memory Bank system with core files: productContext.md, activeContext.md, progress.md, and decisionLog.md.
+
+**Rationale:** The Memory Bank system provides a structured way to maintain project context, track progress, and document decisions. This will help maintain continuity throughout the development process and serve as documentation for future contributors.
+
+**Implementation:** Created the four core Memory Bank files with initial content based on the project overview.
+
+## Template for Future Decisions
+
+## 2026-04-24 - Roadmap and Multi-Author Memory
+
+**Context:** The project is being revived after a long pause. Existing documentation still framed the server around Cline/Roo usage, and memory files described the 2025 direction rather than the current modernization effort.
+
+**Decision:** Use `docs/ROADMAP.md` as the active roadmap and implementation plan, and formalize `memory-bank/` as append-friendly multi-author project memory for humans and coding agents.
+
+**Rationale:** The revival touches documentation, MCP compatibility, provider abstractions, routing, benchmarking, and developer workflow. A roadmap keeps the work coordinated, while shared memory lets future contributors recover context without relying on a single conversation.
+
+**Implementation:** Added `docs/ROADMAP.md`, rewrote `AGENTS.md`, made `CLAUDE.md` defer to shared guidance, added `memory-bank/README.md`, added `memory-bank/sessionLog.md`, and refreshed active/product/progress memory files for the 2026 direction.
+
+```
+## [Date] - [Decision Topic]
+
+**Context:** [What led to this decision]
+
+**Decision:** [What was decided]
+
+**Rationale:** [Why this decision was made]
+
+**Implementation:** [How it will be/was implemented]

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -1,0 +1,61 @@
+# Product Context
+
+Last updated: 2026-04-24
+
+## Project Overview
+
+LocalLama MCP is a Model Context Protocol server for local-first coding-agent workflows. It helps an MCP-capable agent decide when to use local models, free or low-cost remote models, or paid frontier models for coding tasks.
+
+The revived product direction is provider-neutral and client-neutral. It should work well with current coding-agent tools such as Codex, Claude Code, Claw Code, Cursor, GitHub Copilot Agent mode, and generic MCP clients.
+
+## Objectives
+
+- Reduce cost by routing simple or repetitive work to capable local or free models.
+- Preserve quality by routing complex, risky, or broad-context work to stronger models.
+- Use benchmark history and live capability metadata instead of stale hardcoded model assumptions.
+- Provide useful MCP resources for model status, active jobs, cost estimates, benchmark results, and routing explanations.
+- Make model evaluation executable where possible by applying patches and running tests.
+
+## Key Components
+
+### MCP Integration
+
+- Exposes tools and resources through MCP.
+- Should remain safe for model-controlled use.
+- Should support clear setup instructions for modern MCP clients.
+
+### Provider Layer
+
+- Supports local providers such as LM Studio and Ollama.
+- Supports OpenRouter for free, low-cost, and paid models.
+- Should grow toward a common provider contract for model listing, inference, pricing, and capabilities.
+
+### Decision Engine
+
+- Analyzes tasks, estimates context and complexity, and selects models.
+- Should move from model-name heuristics to measured performance, discovered capabilities, and benchmark data.
+- Should explain routing decisions in a way users and agents can audit.
+
+### Benchmarking System
+
+- Compares models by latency, cost, token usage, output quality, and reliability.
+- Should move away from simulated paid-model results.
+- Should prioritize executable outcomes, such as tests passing after an applied patch.
+
+### Cost and Token Monitoring
+
+- Tracks token usage, cost estimates, cache behavior, and available model pricing.
+- Should support modern token accounting and provider-specific pricing metadata.
+
+### Code Search
+
+- Existing code search integrates Python/Retriv and BM25-style search.
+- Future work should decide whether Retriv remains the default or becomes an optional backend.
+
+## Product Principles
+
+- Local-first, not local-only.
+- Provider-neutral, not model-brand-specific.
+- Benchmarks should measure work that matters to coding agents.
+- Documentation should serve both humans and agents.
+- Shared project memory should be updated as work happens.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,0 +1,40 @@
+# Project Progress
+
+Last updated: 2026-04-24
+
+## 2026-04-24 Revival Work
+
+### Completed
+
+- Added `docs/ROADMAP.md` as the modernization and implementation plan.
+- Rewrote `AGENTS.md` as the shared agent-neutral operating guide.
+- Replaced `CLAUDE.md` with a small Claude Code pointer to shared guidance.
+- Added `memory-bank/README.md` with multi-author memory conventions.
+- Added `memory-bank/sessionLog.md` and a first dated session entry.
+- Updated `memory-bank/activeContext.md` with current direction and known baseline issues.
+- Updated `memory-bank/productContext.md` with the revived product framing.
+- Updated README opening and MCP client setup sections for modern agent clients.
+- Updated `.gitignore` so `memory-bank/` and `CLAUDE.md` can be tracked as shared project docs.
+
+### Verified
+
+- `npx tsc --project tsconfig.json --noEmit` succeeds.
+- `npm run build` currently fails on native Windows because the package script uses Unix `cp`.
+- `npm run lint` currently fails because `eslint-plugin-import` is missing.
+
+## Roadmap Status
+
+- Phase 0: Documentation and Shared Memory - in progress
+- Phase 1: Restore Developer Workflow - pending
+- Phase 2: MCP Surface Modernization - pending
+- Phase 3: Provider Abstraction - pending
+- Phase 4: Benchmarking Rebuild - pending
+- Phase 5: Task Understanding and Routing - pending
+- Phase 6: Documentation, Examples, and Release Prep - pending
+
+## Next Steps
+
+- Fix the cross-platform build script.
+- Fix lint dependency/configuration drift.
+- Restore or replace benchmark npm entrypoints.
+- Audit MCP tool definitions and result shapes.

--- a/memory-bank/sessionLog.md
+++ b/memory-bank/sessionLog.md
@@ -1,0 +1,23 @@
+# Session Log
+
+## 2026-04-24 - Documentation Revival
+
+Author: Codex
+
+Summary:
+- Reframed the project as a local-first, provider-neutral MCP server for modern coding agents.
+- Added `docs/ROADMAP.md` as the shared modernization and implementation plan.
+- Updated `AGENTS.md` to be agent-neutral and to reference shared memory.
+- Replaced `CLAUDE.md` with a thin pointer to shared project guidance.
+- Added `memory-bank/README.md` with multi-author memory rules.
+- Updated the README opening and MCP client setup sections for current agent clients.
+- Updated `.gitignore` so `memory-bank/` and `CLAUDE.md` can be versioned as shared documentation.
+
+Verification:
+- Read existing docs and memory-bank files.
+- Confirmed `npx tsc --project tsconfig.json --noEmit` succeeds.
+- Confirmed known broken commands: `npm run build` fails on native Windows due to Unix `cp`; `npm run lint` fails because `eslint-plugin-import` is missing; benchmark scripts reference a missing `run-benchmarks.js`.
+
+Follow-ups:
+- Fix cross-platform build and lint dependency drift.
+- Restore or replace benchmark entrypoints.


### PR DESCRIPTION
## Summary

- Reframe the project documentation around modern MCP-capable coding agents instead of Cline/Roo-specific usage.
- Add `AGENTS.md`, a thin `CLAUDE.md`, and `docs/ROADMAP.md` as shared guidance for future work.
- Establish `memory-bank/` as versioned multi-author project memory with current context, progress, product framing, decisions, and a session log.
- Update `.gitignore` so shared memory docs can be tracked while local workspace files remain ignored.

## Why

The project is being revived after a long pause, and the existing docs pointed contributors toward stale assumptions. The new roadmap gives humans and agents a concrete implementation path for repairing developer workflow, modernizing MCP compatibility, rebuilding provider abstractions, and improving benchmarking/routing logic.

## Validation

- `npx tsc --project tsconfig.json --noEmit`

Known baseline issues are documented in the roadmap and README: native Windows `npm run build` still fails due to Unix `cp`, lint currently requires `eslint-plugin-import`, and benchmark scripts reference a missing entrypoint.