### PR TITLE
feat: MCP install support and self-update feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
-# Cline/Roo specific - IDE and tool configuration
+# Legacy Cline/Roo specific IDE and tool configuration
 .clinerules-architect
 .clinerules-ask
 .clinerules-code
-memory-bank/
-.claude/worktrees/
+memory-bank/*.code-workspace
 
 # Dependency directories
 node_modules/
@@ -106,8 +105,5 @@ locallama.bk1
 mcp-chat.bk1
 lm-studio-models.json
 chats.db
-CLAUDE.md
 package-lock.json
 job-results.txt
-locallama-test.log.1.gz
-locallama-test.log.3.gz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,96 @@
+# AGENTS.md
+
+This file is the shared operating guide for Codex, Claude Code, Claw Code, Cursor, Copilot Agent mode, and any other coding agent working in this repository.
+
+## Project Direction
+
+LocalLama MCP is being revived as a local-first, provider-neutral MCP server for coding-agent workflows. The goal is no longer to target Cline or Roo Code specifically. The server should help modern agents route coding work across local models, free/low-cost remote models, and paid frontier models using measured cost, latency, quality, context capacity, and task fit.
+
+Use the roadmap in `docs/ROADMAP.md` as the source of truth for modernization work.
+
+## Shared Memory
+
+This repo uses `memory-bank/` as multi-author project memory. Before planning non-trivial work, read:
+
+- `memory-bank/README.md`
+- `memory-bank/activeContext.md`
+- `memory-bank/progress.md`
+- `memory-bank/decisionLog.md`
+
+After meaningful work, append or update memory with:
+
+- What changed
+- Why it changed
+- Verification performed
+- Known follow-ups or blockers
+
+Do not rewrite another contributor's historical notes unless the user explicitly asks. Add dated entries instead.
+
+## Development Commands
+
+### Build and Run
+
+- `npm run build` - Compile TypeScript to JavaScript and copy `lock-file.js` to `dist/`
+- `npm start` - Start the MCP server after building
+- `npm run dev` - Development mode with TypeScript watching and auto-restart
+
+Current known issue: `npm run build` uses Unix `cp`, so it fails on native Windows after TypeScript compilation. `npx tsc --project tsconfig.json --noEmit` currently type-checks successfully.
+
+### Testing
+
+- `npm test` - Run all tests
+- `npm test:watch` - Run tests in watch mode
+- Tests live in `test/` and mirror `src/`
+
+### Code Quality
+
+- `npm run lint` - Run ESLint on TypeScript files
+- `npm run lint:fix` - Run ESLint with auto-fix
+
+Current known issue: lint references `eslint-plugin-import`, which is not installed.
+
+### Benchmarking
+
+- `npm run benchmark` - Intended basic benchmark command
+- `npm run benchmark:comprehensive` - Intended comprehensive benchmark command
+
+Current known issue: these scripts reference a missing `run-benchmarks.js`.
+
+## Architecture Overview
+
+The project is a TypeScript ESM MCP server built around these areas:
+
+- `src/index.ts` - MCP server entry point, process lifecycle, lock-file handling, tool routing
+- `src/modules/api-integration/` - MCP tool definitions, resources, routing adapters, OpenRouter integration
+- `src/modules/decision-engine/` - task analysis, model selection, task coordination, code evaluation
+- `src/modules/cost-monitor/` - token accounting, cost estimation, code search/cache helpers
+- `src/modules/benchmark/` - benchmark execution, scoring, summaries, storage
+- `src/modules/lm-studio/`, `src/modules/ollama/`, `src/modules/openrouter/` - provider integrations
+
+## Modernization Priorities
+
+1. Restore reliable local development: cross-platform build, lint dependencies, tests, benchmark entrypoints.
+2. Make MCP responses and schemas match current MCP expectations, including structured tool content where appropriate.
+3. Replace simulated paid benchmarks with real provider adapters behind a common interface.
+4. Replace stale hardcoded model fallbacks with discovered capabilities and benchmark history.
+5. Move prompt understanding toward structured output and validated parsing.
+6. Update docs and examples for current agent clients: Codex, Claude Code, Claw Code, Cursor, Copilot Agent mode, and generic MCP clients.
+
+## Coding Guidelines
+
+- Prefer existing module boundaries and patterns before adding new abstractions.
+- Keep changes scoped. Do not refactor unrelated code while fixing docs or one subsystem.
+- Use TypeScript types for contracts between routing, benchmarking, and provider modules.
+- Prefer structured parsing over regex when model output is expected to be machine-readable.
+- Keep provider-specific logic behind provider modules; do not scatter model-name checks through the decision engine.
+- For benchmark changes, prefer executable scoring: apply patches, run tests, and record results. Heuristic quality scoring should be secondary metadata, not the main pass/fail signal.
+
+## Safety
+
+- Treat MCP tools as model-controlled surfaces. Avoid adding tools that mutate files, run commands, or call paid APIs without clear user/client approval paths.
+- Do not commit API keys, local model inventories with secrets, logs containing tokens, or private benchmark outputs.
+- Be careful with `memory-bank/`: it is project coordination state, not a scratchpad for secrets.
+
+## Python Dependencies
+
+Retriv code search requires Python 3.8+ and dependencies from `requirements.txt`, including `retriv`, `numpy`, `scikit-learn`, and `scipy`. Prefer a virtual environment and configure `PYTHON_PATH`/`RETRIV_PYTHON_PATH` in `.env`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md
+
+Claude Code should use `AGENTS.md` as the primary project guide.
+
+Before starting non-trivial work, read:
+
+- `AGENTS.md`
+- `docs/ROADMAP.md`
+- `memory-bank/README.md`
+- `memory-bank/activeContext.md`
+- `memory-bank/progress.md`
+- `memory-bank/decisionLog.md`
+
+When configuring this MCP server for Claude Code, prefer project-scoped MCP config when sharing with collaborators and keep secrets in environment variables. Append work notes to `memory-bank/` rather than replacing prior contributor context.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,28 @@
-# LocaLLama MCP Server (Testing Branch)
+# LocalLama MCP Server
 
-An MCP Server that works with Roo Code or Cline.Bot (Currently Untested with Claude Desktop or CoPilot MCP VS Code Extension) to optimize costs by intelligently routing coding tasks between local LLMs and paid APIs. Lot's of broken implementation in this.
+LocalLama MCP is a local-first, provider-neutral Model Context Protocol server for modern coding-agent workflows. It is being revived to support current MCP-capable tools such as Codex, Claude Code, Claw Code, Cursor, GitHub Copilot Agent mode, and generic MCP clients.
+
+The project routes coding work across local models, free or low-cost remote models, and paid frontier models using cost, latency, context capacity, benchmark history, and task fit. It is no longer designed around Cline or Roo Code as primary clients.
+
+> Revival status: this repository has useful architecture, but several development commands and benchmark paths are stale. See `docs/ROADMAP.md` for the active modernization plan.
 
 ## Overview
 
-LocalLama MCP Server is designed to reduce token usage and costs by dynamically deciding whether to offload a coding task to a local, less capable instruct LLM (e.g., LM Studio, Ollama) versus using a paid API. Version 1.7.0 introduces smart code task analysis, advanced dependency mapping, and intelligent task decomposition features.
+LocalLama MCP Server is designed to reduce token usage and costs without giving up quality. It dynamically decides whether a coding task should run on a local model, a free or low-cost remote model, or a paid frontier model. The long-term direction is to make those decisions from measured provider capabilities and executable benchmark results instead of hardcoded model assumptions.
+
+## Current Baseline
+
+- `npx tsc --project tsconfig.json --noEmit` succeeds.
+- `npm run build` currently fails on native Windows because the package script uses Unix `cp`.
+- `npm run lint` currently fails because `eslint-plugin-import` is referenced but not installed.
+- `npm run benchmark` and `npm run benchmark:comprehensive` currently reference a missing `run-benchmarks.js`.
+
+## Project Memory and Roadmap
+
+- `AGENTS.md` is the shared operating guide for coding agents.
+- `CLAUDE.md` points Claude Code at the same shared guidance.
+- `memory-bank/` contains multi-author project memory.
+- `docs/ROADMAP.md` is the modernization roadmap and implementation plan.
 
 ## Key Components
 
@@ -263,9 +281,9 @@ PYTHON_DETECT_VENV=true
   - `LOCK_FILE_CHECK_ACTIVE_PROCESS`: Verify if processes in lock files are still running
   - `REMOVE_STALE_LOCK_FILES`: Automatically clean up stale lock files from crashed processes
 
-### Environment Variables for Cline.Bot and Roo Code
+### Environment Variables for MCP Clients
 
-When integrating with Cline.Bot or Roo Code, you can pass these environment variables directly:
+When integrating with Codex, Claude Code, Claw Code, Cursor, GitHub Copilot Agent mode, or another MCP-capable client, pass these environment variables through that client's MCP server configuration:
 
 - For **simple configuration**: Use the basic env variables in your MCP setup
 - For **advanced routing**: Configure thresholds to fine-tune when local vs. cloud models are used
@@ -352,16 +370,18 @@ The server now provides job tracking resources:
 - **Job Progress**: Track the progress of a specific job via `locallama://jobs/progress/{jobId}`
 - **Job Cancellation**: Cancel a running job using the `cancel_job` tool
 
-### Using with Cline.Bot
+### Using with Modern MCP Clients
 
-To use this MCP Server with Cline.Bot, add it to your Cline MCP settings:
+Build the server, then configure your MCP client to launch `node dist/index.js` with the environment variables relevant to your local setup.
+
+Generic stdio MCP configuration:
 
 ```json
 {
   "mcpServers": {
     "locallama": {
       "command": "node",
-      "args": ["/path/to/locallama-mcp"],
+      "args": ["/path/to/locallama-mcp/dist/index.js"],
       "env": {
         "LM_STUDIO_ENDPOINT": "http://localhost:1234/v1",
         "OLLAMA_ENDPOINT": "http://localhost:11434/api",
@@ -379,7 +399,9 @@ To use this MCP Server with Cline.Bot, add it to your Cline MCP settings:
 }
 ```
 
-Once configured, you can use the MCP tools in Cline.Bot:
+Claude Code project-scoped configuration can use the same server shape in `.mcp.json`. Codex users should add this server through Codex MCP configuration or the Codex CLI, using the same command, args, and environment values.
+
+Once configured, the MCP client can discover and use tools such as:
 
 - `get_free_models`: Retrieve the list of free models from OpenRouter
 - `clear_openrouter_tracking`: Force a fresh update of OpenRouter models if you encounter issues
@@ -389,7 +411,7 @@ Once configured, you can use the MCP tools in Cline.Bot:
 - `retriv_init`: Initialize and configure Retriv for code search and indexing
 - `cancel_job`: Cancel a running job to prevent runaway costs
 
-Example usage in Cline.Bot:
+Example tool call:
 
 ```
 /use_mcp_tool locallama clear_openrouter_tracking {}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,142 @@
+# LocalLama MCP Revival Roadmap
+
+Last updated: 2026-04-24
+
+## Purpose
+
+LocalLama MCP is being revived as a local-first, provider-neutral MCP server for modern coding agents. The project should help agents choose between local models, free or low-cost remote models, and paid frontier models using measured task fit, cost, latency, context capacity, reliability, and benchmark history.
+
+The project should support current MCP-capable tools such as Codex, Claude Code, Claw Code, Cursor, GitHub Copilot Agent mode, and generic MCP clients. It should not be designed around Cline or Roo Code as primary clients.
+
+## Current Baseline
+
+- TypeScript source type-checks with `npx tsc --project tsconfig.json --noEmit`.
+- `npm run build` fails on native Windows after TypeScript compilation because it uses Unix `cp`.
+- `npm run lint` fails because `eslint-plugin-import` is referenced but not installed.
+- `npm run benchmark` and `npm run benchmark:comprehensive` reference missing `run-benchmarks.js`.
+- Tool definitions include duplication and some stale descriptions.
+- Benchmarking still contains simulated paid-model paths.
+- Routing still relies on hardcoded model-name heuristics and stale fallback models.
+- Documentation still contains old Cline/Roo positioning in several places.
+
+## Roadmap
+
+### Phase 0: Documentation and Shared Memory
+
+Status: in progress
+
+- Update `AGENTS.md` as the primary agent-neutral operating guide.
+- Keep `CLAUDE.md` as a thin Claude Code pointer to shared docs.
+- Add a multi-author memory convention under `memory-bank/`.
+- Add this roadmap as the implementation source of truth.
+- Update README positioning away from Cline/Roo-specific language.
+
+Exit criteria:
+
+- A new contributor can identify current goals, known broken commands, and where to leave project state.
+
+### Phase 1: Restore Developer Workflow
+
+Status: pending
+
+- Make `npm run build` cross-platform by replacing `cp` with a Node script or `cpy`-style package.
+- Fix lint by installing `eslint-plugin-import` or removing the unused import rule.
+- Restore or remove benchmark npm scripts so package commands are truthful.
+- Run `npm test` after build script repair.
+- Document any environment-specific requirements for Windows, WSL, macOS, and Linux.
+
+Exit criteria:
+
+- `npm run build`, `npm run lint`, and `npm test` complete or fail only for documented external-service reasons.
+
+### Phase 2: MCP Surface Modernization
+
+Status: pending
+
+- Audit tool result shapes against current MCP content expectations.
+- Remove duplicate tool definitions in `api-integration/tool-definition`.
+- Add clearer tool descriptions for model-controlled agent use.
+- Split read-only tools from tools that execute work, cancel jobs, mutate benchmark state, or call paid APIs.
+- Consider optional Streamable HTTP transport while preserving stdio.
+- Add client setup examples for Codex, Claude Code, Cursor, Copilot Agent mode, and generic MCP clients.
+
+Exit criteria:
+
+- MCP tool discovery is concise, client-neutral, and safe for modern agents.
+
+### Phase 3: Provider Abstraction
+
+Status: pending
+
+- Define one provider interface for model listing, chat/completion calls, token usage, pricing, and capability metadata.
+- Implement adapters for LM Studio, Ollama, OpenRouter, and at least one direct paid provider.
+- Keep provider-specific quirks inside provider modules.
+- Replace hardcoded stale fallback models with configured defaults and discovered capabilities.
+- Track model metadata: context window, cost, tool support, structured output support, reasoning controls, latency, throughput, and local resource cost where available.
+
+Exit criteria:
+
+- Routing and benchmarking consume a common provider contract instead of scattered provider checks.
+
+### Phase 4: Benchmarking Rebuild
+
+Status: pending
+
+- Replace simulated paid benchmarks with real provider calls or explicitly labeled dry-run mode.
+- Make benchmark results reproducible and structured.
+- Add benchmark suites by task class:
+  - Simple function/code generation
+  - Multi-file code editing
+  - Bug fix with tests
+  - Refactor with behavior preservation
+  - Documentation and explanation
+- Prefer executable scoring over text heuristics: apply diffs, run tests, and record pass/fail.
+- Keep heuristic quality scores as supplemental metadata only.
+- Add cost and latency reporting per successful task.
+
+Exit criteria:
+
+- Benchmark output can be trusted by the decision engine for model routing.
+
+### Phase 5: Task Understanding and Routing
+
+Status: pending
+
+- Replace regex-heavy prompt parsing with validated structured outputs where supported.
+- Add task classification fields: task type, risk level, expected artifact, relevant files, test strategy, context needs, latency tolerance, and cost ceiling.
+- Route based on measured performance and capabilities before model-name heuristics.
+- Add cold-start routing rules for unknown models.
+- Track routing decisions and outcomes for later calibration.
+
+Exit criteria:
+
+- The decision engine can explain why a model was selected using current evidence, not just hardcoded names.
+
+### Phase 6: Documentation, Examples, and Release Prep
+
+Status: pending
+
+- Rewrite README into a current quickstart plus architecture overview.
+- Add `docs/CONFIGURATION.md`, `docs/MCP_CLIENTS.md`, and `docs/BENCHMARKING.md` if the README grows too large.
+- Update `.env.example` with current provider and benchmark settings.
+- Add troubleshooting for local model servers, OpenRouter failures, Python/Retriv setup, and lock-file issues.
+- Decide whether old Roo-specific files should remain, be archived, or be removed.
+
+Exit criteria:
+
+- A user can install, configure, run, benchmark, and connect the MCP server from current docs.
+
+## Open Design Decisions
+
+- Whether to keep Retriv or move code search toward a simpler built-in index plus optional semantic backends.
+- Whether to support only stdio initially or add Streamable HTTP during MCP modernization.
+- Which direct paid provider should be implemented first.
+- How much benchmark data should be committed versus treated as local generated output.
+- Whether old `.roomodes` and `.rooignore` files are useful historical artifacts or should be removed.
+
+## Working Agreement
+
+- Keep `AGENTS.md` and this roadmap aligned when project direction changes.
+- Append meaningful decisions to `memory-bank/decisionLog.md`.
+- Update `memory-bank/progress.md` when finishing a roadmap item.
+- Update `memory-bank/activeContext.md` when the current focus changes.

--- a/docs/superpowers/plans/2026-05-18-mcp-install-and-self-update.md
+++ b/docs/superpowers/plans/2026-05-18-mcp-install-and-self-update.md
@@ -1,0 +1,567 @@
+# MCP Install & Self-Update Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix Windows build, add a self-update module with two MCP tools (`check_for_updates`, `update_server`), add a startup update check, then clone/build/register the server in Claude Code.
+
+**Architecture:** A standalone `src/modules/updater/index.ts` module compares local git SHA to GitHub API and optionally runs `git pull && npm install && npm run build`. The module is wired into the existing tool dispatch switch in `src/index.ts` and fires a silent startup check after `server.connect()`. Tool definitions are added to the existing `getAvailableTools()` array in `src/modules/api-integration/tool-definition/index.ts`.
+
+**Tech Stack:** TypeScript ESM, Node.js `child_process.execSync`, `https` built-in (no new deps), Jest for tests, `@modelcontextprotocol/sdk`.
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `package.json` | Fix `build` script — replace Unix `cp` with cross-platform Node inline |
+| `src/modules/updater/index.ts` | **New** — types + `getLocalSha`, `getRemoteSha`, `checkForUpdates`, `runUpdate` |
+| `test/modules/updater/index.test.ts` | **New** — unit tests for updater module |
+| `src/modules/api-integration/tool-definition/index.ts` | Add `check_for_updates` and `update_server` to `getAvailableTools()` |
+| `src/index.ts` | Add `check_for_updates` and `update_server` cases to switch; add startup check after `server.connect()` |
+| `C:\Users\herat\.claude\settings.json` | Add `mcpServers` entry pointing to installed clone |
+
+---
+
+## Task 1: Fix Windows Build Script
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Edit build script**
+
+Open `package.json`. Replace the `build` script value:
+
+```json
+"build": "tsc --project tsconfig.json && node -e \"const fs=require('fs');fs.mkdirSync('dist/utils',{recursive:true});fs.copyFileSync('src/utils/lock-file.js','dist/utils/lock-file.js');\""
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run from the worktree root `C:\Users\herat\source\locallama-mcp\.claude\worktrees\cool-satoshi-e7371b`:
+
+```
+npx tsc --project tsconfig.json --noEmit
+```
+
+Expected: exits 0, no errors printed.
+
+- [ ] **Step 3: Commit**
+
+```
+git add package.json
+git commit -m "fix: cross-platform build script for Windows"
+```
+
+---
+
+## Task 2: Create Updater Module Types and Helpers
+
+**Files:**
+- Create: `src/modules/updater/index.ts`
+
+- [ ] **Step 1: Write failing test first**
+
+Create `test/modules/updater/index.test.ts`:
+
+```typescript
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+
+// We test the pure logic; shell/network calls are mocked.
+jest.mock('child_process');
+jest.mock('https');
+
+import { execSync } from 'child_process';
+import * as https from 'https';
+
+const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+
+describe('getLocalSha', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  it('returns trimmed SHA string when git succeeds', async () => {
+    mockExecSync.mockReturnValue(Buffer.from('abc1234\n'));
+    const { getLocalSha } = await import('../../../dist/modules/updater/index.js');
+    const sha = await getLocalSha();
+    expect(sha).toBe('abc1234');
+  });
+
+  it('returns null when git is not available', async () => {
+    mockExecSync.mockImplementation(() => { throw new Error('git not found'); });
+    const { getLocalSha } = await import('../../../dist/modules/updater/index.js');
+    const sha = await getLocalSha();
+    expect(sha).toBeNull();
+  });
+});
+
+describe('checkForUpdates', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  it('returns upToDate true when SHAs match', async () => {
+    mockExecSync.mockReturnValue(Buffer.from('abc1234\n'));
+    // getRemoteSha is tested via integration; mock it at module boundary
+    const updater = await import('../../../dist/modules/updater/index.js');
+    jest.spyOn(updater, 'getRemoteSha').mockResolvedValue('abc1234');
+    const result = await updater.checkForUpdates();
+    expect(result.upToDate).toBe(true);
+    expect(result.localSha).toBe('abc1234');
+    expect(result.remoteSha).toBe('abc1234');
+  });
+
+  it('returns upToDate false when SHAs differ', async () => {
+    mockExecSync.mockReturnValue(Buffer.from('abc1234\n'));
+    const updater = await import('../../../dist/modules/updater/index.js');
+    jest.spyOn(updater, 'getRemoteSha').mockResolvedValue('def5678');
+    const result = await updater.checkForUpdates();
+    expect(result.upToDate).toBe(false);
+  });
+
+  it('returns upToDate null on error', async () => {
+    mockExecSync.mockImplementation(() => { throw new Error('git not found'); });
+    const updater = await import('../../../dist/modules/updater/index.js');
+    jest.spyOn(updater, 'getRemoteSha').mockRejectedValue(new Error('network'));
+    const result = await updater.checkForUpdates();
+    expect(result.upToDate).toBeNull();
+    expect(result.error).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm it fails (module not yet created)**
+
+```
+npx tsc --project tsconfig.json --noEmit 2>&1 | head -5
+```
+
+Expected: TypeScript error about missing `src/modules/updater/index.ts` or test import.
+
+- [ ] **Step 3: Create the updater module**
+
+Create `src/modules/updater/index.ts`:
+
+```typescript
+import { execSync } from 'child_process';
+import https from 'https';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { logger } from '../../utils/logger.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+// Resolve install root: dist/modules/updater -> project root
+const INSTALL_ROOT = join(__dirname, '../../..');
+
+const GITHUB_API_URL = 'https://api.github.com/repos/Heratiki/locallama-mcp/commits/future-testing';
+
+export interface UpdateCheckResult {
+  upToDate: boolean | null;
+  localSha: string | null;
+  remoteSha: string | null;
+  error?: string;
+}
+
+export interface UpdateResult {
+  success: boolean;
+  completedSteps: string[];
+  failedStep?: string;
+  error?: string;
+  restartRequired: boolean;
+}
+
+export async function getLocalSha(): Promise<string | null> {
+  try {
+    const output = execSync('git rev-parse HEAD', {
+      cwd: INSTALL_ROOT,
+      stdio: 'pipe',
+    });
+    return output.toString().trim();
+  } catch {
+    return null;
+  }
+}
+
+export async function getRemoteSha(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const req = https.get(
+      GITHUB_API_URL,
+      { headers: { 'User-Agent': 'locallama-mcp-updater' } },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+        res.on('end', () => {
+          try {
+            const parsed = JSON.parse(data) as { sha?: string };
+            resolve(parsed.sha ?? null);
+          } catch {
+            resolve(null);
+          }
+        });
+      }
+    );
+    req.on('error', () => resolve(null));
+    req.setTimeout(5000, () => { req.destroy(); resolve(null); });
+  });
+}
+
+export async function checkForUpdates(): Promise<UpdateCheckResult> {
+  try {
+    const [localSha, remoteSha] = await Promise.all([getLocalSha(), getRemoteSha()]);
+    if (localSha === null || remoteSha === null) {
+      return {
+        upToDate: null,
+        localSha,
+        remoteSha,
+        error: localSha === null ? 'Could not read local git SHA' : 'Could not reach GitHub API',
+      };
+    }
+    return { upToDate: localSha === remoteSha, localSha, remoteSha };
+  } catch (err) {
+    return {
+      upToDate: null,
+      localSha: null,
+      remoteSha: null,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export async function runUpdate(): Promise<UpdateResult> {
+  const completedSteps: string[] = [];
+  const steps: Array<{ name: string; cmd: string }> = [
+    { name: 'git pull', cmd: 'git pull' },
+    { name: 'npm install', cmd: 'npm install' },
+    { name: 'npm run build', cmd: 'npm run build' },
+  ];
+
+  for (const step of steps) {
+    try {
+      execSync(step.cmd, { cwd: INSTALL_ROOT, stdio: 'pipe' });
+      completedSteps.push(step.name);
+    } catch (err) {
+      return {
+        success: false,
+        completedSteps,
+        failedStep: step.name,
+        error: err instanceof Error ? err.message : String(err),
+        restartRequired: false,
+      };
+    }
+  }
+
+  return {
+    success: true,
+    completedSteps,
+    restartRequired: true,
+  };
+}
+
+export async function runStartupCheck(): Promise<void> {
+  try {
+    const localSha = await getLocalSha();
+    if (localSha === null) return; // not a git install, skip silently
+    const remoteSha = await getRemoteSha();
+    if (remoteSha === null) return; // network unavailable, skip silently
+    if (localSha !== remoteSha) {
+      logger.warn(
+        `locallama-mcp update available. Remote: ${remoteSha.slice(0, 7)}, Local: ${localSha.slice(0, 7)}. ` +
+        `Call the check_for_updates or update_server tool to apply.`
+      );
+    }
+  } catch {
+    // never throw on startup
+  }
+}
+```
+
+- [ ] **Step 4: Compile and run tests**
+
+```
+npx tsc --project tsconfig.json --noEmit
+NODE_OPTIONS=--experimental-vm-modules npx jest test/modules/updater/index.test.ts --config=jest.config.mjs -t "getLocalSha"
+```
+
+Expected: `getLocalSha` describe block passes.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/modules/updater/index.ts test/modules/updater/index.test.ts
+git commit -m "feat: add updater module with check and update functions"
+```
+
+---
+
+## Task 3: Register Tools in Tool Definition Provider
+
+**Files:**
+- Modify: `src/modules/api-integration/tool-definition/index.ts`
+
+The two new tools are always available (no Python/OpenRouter gate). Add them to the `tools` array in `getAvailableTools()` before the `return tools` line.
+
+- [ ] **Step 1: Add tool definitions**
+
+In `src/modules/api-integration/tool-definition/index.ts`, locate the line:
+
+```typescript
+    return tools;
+```
+
+Insert immediately before it:
+
+```typescript
+      tools.push(
+        {
+          name: 'check_for_updates',
+          description: 'Check whether the running locallama-mcp server is up to date with the latest commit on the future-testing branch on GitHub. Returns upToDate status, local SHA, remote SHA, and any error.',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: []
+          }
+        },
+        {
+          name: 'update_server',
+          description: 'Pull the latest changes from GitHub and rebuild the server. Runs git pull, npm install, and npm run build in sequence. IMPORTANT: The server must be manually restarted after this completes for changes to take effect.',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+            required: []
+          }
+        }
+      );
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```
+npx tsc --project tsconfig.json --noEmit
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/modules/api-integration/tool-definition/index.ts
+git commit -m "feat: register check_for_updates and update_server MCP tools"
+```
+
+---
+
+## Task 4: Wire Tools into Tool Call Handler and Add Startup Check
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add import at top of file**
+
+In `src/index.ts`, after the existing imports (around line 16), add:
+
+```typescript
+import { checkForUpdates, runUpdate, runStartupCheck } from './modules/updater/index.js';
+```
+
+- [ ] **Step 2: Add switch cases**
+
+In `setupToolCallHandler()`, locate the `default:` case in the switch statement (around line 241):
+
+```typescript
+                default:
+                  logger.error(`Unknown tool: ${name}`);
+                  throw new Error(`Unknown tool: ${name}`);
+```
+
+Insert before `default:`:
+
+```typescript
+                case 'check_for_updates': {
+                  const updateCheck = await checkForUpdates();
+                  return JSON.stringify(updateCheck);
+                }
+                case 'update_server': {
+                  const updateResult = await runUpdate();
+                  return JSON.stringify(updateResult);
+                }
+```
+
+- [ ] **Step 3: Add startup check**
+
+In the `run()` method, locate this line (around line 334):
+
+```typescript
+      await this.server.connect(transport);
+      logger.info(`${connectionInfo} (PID: ${process.pid})`);
+```
+
+Add after the `logger.info` line:
+
+```typescript
+      // Fire-and-forget startup update check — never blocks startup
+      runStartupCheck().catch(() => undefined);
+```
+
+- [ ] **Step 4: Verify TypeScript**
+
+```
+npx tsc --project tsconfig.json --noEmit
+```
+
+Expected: exits 0.
+
+- [ ] **Step 5: Run full build**
+
+```
+npm run build
+```
+
+Expected: TypeScript compiles, `dist/utils/lock-file.js` copied successfully, exits 0.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/index.ts
+git commit -m "feat: wire updater tools into tool handler and add startup check"
+```
+
+---
+
+## Task 5: Clone, Build, and Register in Claude Code
+
+This task is performed in a terminal (PowerShell), not in the codebase itself.
+
+- [ ] **Step 1: Create install directory**
+
+```powershell
+New-Item -ItemType Directory -Force -Path "C:\Users\herat\.claude\mcp-servers"
+```
+
+- [ ] **Step 2: Clone future-testing branch**
+
+```powershell
+git clone --branch future-testing https://github.com/Heratiki/locallama-mcp.git "C:\Users\herat\.claude\mcp-servers\locallama-mcp"
+```
+
+Expected: clone succeeds, `future-testing` branch checked out.
+
+- [ ] **Step 3: Install dependencies**
+
+```powershell
+cd "C:\Users\herat\.claude\mcp-servers\locallama-mcp"
+npm install
+```
+
+Expected: `node_modules` populated, exits 0.
+
+- [ ] **Step 4: Build**
+
+```powershell
+npm run build
+```
+
+Expected: `dist/` created, `dist/index.js` and `dist/utils/lock-file.js` present, exits 0.
+
+> Note: The Windows build fix from Task 1 must be on the `future-testing` branch (pushed to GitHub) before this step works. If the clone still has the old Unix `cp` script, apply the same fix manually in the cloned copy before running build.
+
+- [ ] **Step 5: Register MCP in Claude Code settings**
+
+Open `C:\Users\herat\.claude\settings.json`. Add `mcpServers` at the top level (alongside existing `hooks`, `statusLine`, etc.):
+
+```json
+"mcpServers": {
+  "locallama-mcp": {
+    "command": "node",
+    "args": ["C:\\Users\\herat\\.claude\\mcp-servers\\locallama-mcp\\dist\\index.js"],
+    "env": {}
+  }
+}
+```
+
+Full resulting `settings.json` structure (merge, do not replace other keys):
+
+```json
+{
+  "mcpServers": {
+    "locallama-mcp": {
+      "command": "node",
+      "args": ["C:\\Users\\herat\\.claude\\mcp-servers\\locallama-mcp\\dist\\index.js"],
+      "env": {}
+    }
+  },
+  "hooks": { ... },
+  "statusLine": { ... },
+  "enabledPlugins": { ... },
+  "effortLevel": "medium",
+  "model": "sonnet"
+}
+```
+
+- [ ] **Step 6: Restart Claude Code**
+
+Close and reopen Claude Code (or reload the MCP server). Verify `locallama-mcp` appears in the available MCP tools list.
+
+- [ ] **Step 7: Smoke test**
+
+Ask Claude Code to call `check_for_updates`. Expected response shape:
+
+```json
+{
+  "upToDate": true,
+  "localSha": "<7-char SHA>...",
+  "remoteSha": "<same SHA>..."
+}
+```
+
+If `upToDate` is `false`, the GitHub branch has commits ahead of the clone — call `update_server` and restart.
+
+---
+
+## Task 6: Update Memory Bank
+
+**Files:**
+- Modify: `memory-bank/progress.md`
+- Modify: `memory-bank/decisionLog.md`
+
+- [ ] **Step 1: Append to progress.md**
+
+Add dated entry:
+
+```markdown
+## 2026-05-18 — MCP Install & Self-Update
+
+- Fixed Windows build script (Unix cp → Node inline copy)
+- Added `src/modules/updater/index.ts` with `checkForUpdates`, `runUpdate`, `runStartupCheck`
+- Registered `check_for_updates` and `update_server` MCP tools
+- Added fire-and-forget startup update check after server.connect()
+- Cloned future-testing branch to C:\Users\herat\.claude\mcp-servers\locallama-mcp
+- Registered server in Claude Code settings.json
+```
+
+- [ ] **Step 2: Append to decisionLog.md**
+
+```markdown
+## 2026-05-18 — Self-Update Strategy
+
+Decision: Use git SHA comparison (local `git rev-parse HEAD` vs GitHub API) rather than semver/npm-registry check.
+
+Reason: Project tracks a branch (`future-testing`), not published releases. SHA comparison detects any commit, not just tagged versions.
+
+Trade-off: Requires `git` on PATH in the runtime environment. Silent skip if git unavailable.
+```
+
+- [ ] **Step 3: Commit**
+
+```
+git add memory-bank/progress.md memory-bank/decisionLog.md
+git commit -m "docs: update memory bank after self-update implementation"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** All items covered — Windows fix (Task 1), updater module (Task 2), tool registration (Task 3), wire-up + startup check (Task 4), clone/build/register (Task 5).
+- **Type consistency:** `UpdateCheckResult` and `UpdateResult` defined in Task 2 and referenced by name in Tasks 3/4 — matches throughout.
+- **`getRemoteSha` export:** Must be exported (not just internal) because tests spy on it. The implementation in Task 2 exports it. ✓
+- **`runStartupCheck` import:** Added to the import line in Task 4 Step 1. ✓
+- **Windows build fix prerequisite:** Task 5 Step 4 notes the dependency — if `future-testing` branch hasn't had Task 1 pushed, a manual workaround is described.
+- **`inputSchema.required: []`** for no-arg tools — valid MCP schema. ✓

--- a/docs/superpowers/specs/2026-05-18-mcp-install-and-self-update-design.md
+++ b/docs/superpowers/specs/2026-05-18-mcp-install-and-self-update-design.md
@@ -1,0 +1,180 @@
+# Design: MCP Installation & Self-Update Feature
+
+**Date:** 2026-05-18  
+**Branch:** future-testing  
+**Repo:** https://github.com/Heratiki/locallama-mcp  
+**Status:** Approved, pending implementation
+
+---
+
+## Overview
+
+Two goals:
+
+1. Clone and install the `future-testing` branch as a live MCP server that Claude Code (and any MCP-capable agent) can use at `C:\Users\herat\.claude\mcp-servers\locallama-mcp`.
+2. Add a self-update capability to the server so it can detect and apply upstream changes from GitHub.
+
+---
+
+## Part 1: Installation
+
+### Clone Location
+
+```
+C:\Users\herat\.claude\mcp-servers\locallama-mcp
+```
+
+Clone command:
+
+```
+git clone --branch future-testing https://github.com/Heratiki/locallama-mcp.git C:\Users\herat\.claude\mcp-servers\locallama-mcp
+```
+
+### Windows Build Fix (prerequisite)
+
+`package.json` build script uses Unix `cp`, which fails on native Windows. Must patch before building:
+
+```json
+"build": "tsc --project tsconfig.json && node -e \"const fs=require('fs'); fs.mkdirSync('dist/utils',{recursive:true}); fs.copyFileSync('src/utils/lock-file.js','dist/utils/lock-file.js');\""
+```
+
+### Build & Install
+
+```
+cd C:\Users\herat\.claude\mcp-servers\locallama-mcp
+npm install
+npm run build
+```
+
+### Claude Code MCP Registration
+
+Add to `C:\Users\herat\.claude\settings.json` under `mcpServers`:
+
+```json
+"mcpServers": {
+  "locallama-mcp": {
+    "command": "node",
+    "args": ["C:\\Users\\herat\\.claude\\mcp-servers\\locallama-mcp\\dist\\index.js"],
+    "env": {}
+  }
+}
+```
+
+For other MCP clients (Cursor, Copilot Agent, Codex, generic), point their MCP config at the same `dist/index.js` path using stdio transport.
+
+---
+
+## Part 2: Self-Update Feature
+
+### Approach: Git SHA Comparison (Option A)
+
+Compare local `git rev-parse HEAD` against the latest commit SHA on `future-testing` via GitHub API. No version parsing required — works naturally for a branch-tracked install.
+
+GitHub API endpoint (unauthenticated, 60 req/hr):
+
+```
+GET https://api.github.com/repos/Heratiki/locallama-mcp/commits/future-testing
+```
+
+### New Module
+
+**File:** `src/modules/updater/index.ts`
+
+Responsibilities:
+- `getLocalSha(): Promise<string | null>` — runs `git rev-parse HEAD` via child process in install dir; returns `null` if git unavailable or not a git repo
+- `getRemoteSha(): Promise<string | null>` — calls GitHub API, extracts `data.sha`; returns `null` on network failure
+- `checkForUpdates(): Promise<UpdateCheckResult>` — compares SHAs, returns structured result
+- `runUpdate(): Promise<UpdateResult>` — runs `git pull`, `npm install`, `npm run build` sequentially in install dir; stops and returns failure info at first failed step
+
+```typescript
+interface UpdateCheckResult {
+  upToDate: boolean | null;  // null = check failed
+  localSha: string | null;
+  remoteSha: string | null;
+  error?: string;
+}
+
+interface UpdateResult {
+  success: boolean;
+  completedSteps: string[];
+  failedStep?: string;
+  error?: string;
+  restartRequired: boolean;
+}
+```
+
+### Startup Check
+
+In `src/index.ts`, after server initialization, fire-and-forget:
+
+```typescript
+checkForUpdates().then(result => {
+  if (result.upToDate === false) {
+    logger.warn(`locallama-mcp update available. Remote: ${result.remoteSha?.slice(0,7)}. Run check_for_updates tool or call update_server to apply.`);
+  }
+}).catch(() => { /* never throw on startup */ });
+```
+
+- Failures silently swallowed — server always starts normally
+- Not a git repo: skip entirely
+- `git` not on PATH: log single warning, skip
+
+### New MCP Tools
+
+Two tools registered via existing `toolDefinitionProvider`:
+
+#### `check_for_updates`
+
+- **Description:** Check whether the running locallama-mcp server is up to date with the latest commit on the `future-testing` branch on GitHub.
+- **Input:** none
+- **Output:** `UpdateCheckResult` as JSON text content
+- **Errors:** Returned as structured result, never thrown
+
+#### `update_server`
+
+- **Description:** Pull the latest changes from GitHub and rebuild the server. The server must be restarted after this completes for changes to take effect.
+- **Input:** none
+- **Output:** `UpdateResult` as JSON text content including a `restartRequired: true` field and restart instructions
+- **Steps executed:**
+  1. `git pull`
+  2. `npm install`
+  3. `npm run build`
+- **Stops** at first failure, reports which step failed
+
+### Safety Constraints
+
+- GitHub API call is read-only and unauthenticated
+- `update_server` runs commands only in the known install directory (`__dirname`-relative path resolved at startup) — no user input is passed to shell
+- No auto-update — startup check reads only; `update_server` only runs on explicit tool call
+- After update, server must be restarted manually (stdio MCP cannot hot-reload)
+- `update_server` tool description must clearly state restart is required
+
+---
+
+## Files to Create / Modify
+
+| File | Change |
+|------|--------|
+| `src/modules/updater/index.ts` | New — updater module |
+| `src/modules/api-integration/tool-definition/index.ts` | Register two new tools |
+| `src/index.ts` | Add startup update check |
+| `package.json` | Fix Windows build script |
+
+---
+
+## Out of Scope
+
+- Automatic restart after update
+- Rollback on failed update
+- Authenticated GitHub API calls (not needed at this usage rate)
+- Update checking on non-git installs (npm global, etc.)
+
+---
+
+## Notes for Other Agents
+
+- Read `AGENTS.md` and `memory-bank/activeContext.md` before touching code
+- Known broken: `npm run build` on Windows (fix is in scope above), `npm run lint` (missing `eslint-plugin-import`), benchmark scripts
+- Use existing `logger` utility from `src/utils/logger.ts` — do not introduce a new logging dependency
+- Keep provider-specific and tool-specific logic in their respective modules; updater is a standalone module
+- After implementation, append to `memory-bank/progress.md` and `memory-bank/decisionLog.md`

--- a/memory-bank/README.md
+++ b/memory-bank/README.md
@@ -1,0 +1,38 @@
+# Memory Bank
+
+This directory is shared project memory for humans and coding agents. It exists so every contributor can quickly recover the current project direction, decisions, and unfinished work without relying on one chat transcript.
+
+## Files
+
+- `activeContext.md` - current focus, working assumptions, and immediate next work
+- `progress.md` - completed work and roadmap progress
+- `decisionLog.md` - dated decisions and rationale
+- `productContext.md` - durable product direction and goals
+- `sessionLog.md` - append-only notes from individual work sessions
+
+## Multi-Author Rules
+
+- Read `AGENTS.md`, `docs/ROADMAP.md`, and this README before non-trivial work.
+- Prefer appending dated entries over rewriting history.
+- Keep entries factual: what changed, why, verification, and next steps.
+- Use absolute dates such as `2026-04-24`, not "today" or "yesterday".
+- Do not store secrets, API keys, private prompts, or sensitive logs here.
+- If a prior note is wrong, add a correction with a date and rationale instead of silently deleting it.
+
+## Session Entry Template
+
+```md
+## 2026-04-24 - Short Title
+
+Author: name or agent/tool
+
+Summary:
+- What changed
+- Why it changed
+
+Verification:
+- Commands run or checks performed
+
+Follow-ups:
+- Remaining work, blockers, or open questions
+```

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,0 +1,35 @@
+# Active Context
+
+Last updated: 2026-04-24
+
+## Current Focus
+
+The project is being revived and repositioned away from Cline/Roo-specific usage. The new direction is a local-first, provider-neutral MCP server for modern coding agents such as Codex, Claude Code, Claw Code, Cursor, GitHub Copilot Agent mode, and generic MCP clients.
+
+The current workstream is documentation and shared project memory. `docs/ROADMAP.md` is now the modernization source of truth.
+
+## Baseline Findings
+
+- `npx tsc --project tsconfig.json --noEmit` succeeds.
+- `npm run build` fails on native Windows after TypeScript compilation because the script uses Unix `cp`.
+- `npm run lint` fails because `eslint-plugin-import` is referenced by `eslint.config.js` but is not installed.
+- `npm run benchmark` and `npm run benchmark:comprehensive` reference missing `run-benchmarks.js`.
+- Benchmarking still includes simulated paid-model paths.
+- Routing still includes stale hardcoded model fallbacks and model-name heuristics.
+- README opening and MCP client setup sections now use current agent-neutral positioning.
+
+## Current Goals
+
+- Finish documentation refresh.
+- Repair the local developer workflow.
+- Modernize MCP tool definitions and result shapes.
+- Rebuild provider and benchmark layers around real provider adapters and executable scoring.
+- Move routing from hardcoded model names toward discovered capabilities and benchmark history.
+
+## Open Questions
+
+- Should the project keep Retriv as the main code search backend, or make it optional behind a simpler built-in index?
+- Should Streamable HTTP support be added during the MCP modernization phase or after stdio is cleaned up?
+- Which direct paid provider should be implemented first alongside OpenRouter?
+- Should old Roo-specific files such as `.roomodes` and `.rooignore` be archived or removed?
+- How much generated benchmark data should stay in the repository?

--- a/memory-bank/decisionLog.md
+++ b/memory-bank/decisionLog.md
@@ -1,0 +1,336 @@
+# Decision Log
+
+This document tracks key architectural and technical decisions made throughout the project, along with their rationale.
+
+## Table of Contents
+
+1. [Free Model Benchmarking Improvements (2/27/2025)](#2272025---free-model-benchmarking-improvements)
+2. [Code Quality Assessment Enhancement (2/27/2025)](#2272025---code-quality-assessment-enhancement)
+3. [Fair Model Selection Approach (2/27/2025)](#2272025---fair-model-selection-approach)
+4. [OpenRouter Free Model Testing (2/26/2025)](#2262025---openrouter-free-model-testing)
+5. [TypeScript Error Fixes in API Integration Tools (2/26/2025)](#2262025---typescript-error-fixes-in-api-integration-tools)
+6. [OpenRouter Integration (2/26/2025)](#2262025---openrouter-integration)
+7. [Security and Organization Improvements (2/26/2025)](#2262025---security-and-organization-improvements)
+8. [Version Management Policy (2/26/2025)](#2262025---version-management-policy)
+9. [OpenRouter Resources Exposure (2/26/2025)](#2262025---openrouter-resources-exposure)
+10. [Code Cleanup and Bug Fixes (2/26/2025)](#2262025---code-cleanup-and-bug-fixes)
+11. [Preemptive Decision Framework (2/26/2025)](#2262025---preemptive-decision-framework-implementation)
+12. [Comprehensive Benchmark Execution (2/26/2025)](#2262025---comprehensive-benchmark-execution)
+13. [User-Driven Model Selection (2/26/2025)](#2262025---user-driven-model-selection-and-configuration)
+14. [Comprehensive Model Benchmarking (2/26/2025)](#2262025---comprehensive-model-benchmarking-approach)
+15. [Benchmark Task Selection (2/26/2025)](#2262025---benchmark-task-selection-strategy)
+16. [Benchmarking System Implementation (2/26/2025)](#2262025---benchmarking-system-implementation)
+17. [Unit Testing Strategy (2/25/2025)](#2252025---unit-testing-strategy)
+18. [Model Context Window Tracking (2/25/2025)](#2252025---model-context-window-tracking)
+19. [Decision Engine Optimization (2/25/2025)](#2252025---decision-engine-optimization)
+20. [API Integration Approach (2/25/2025)](#2252025---api-integration-approach)
+21. [Decision Engine Design (2/25/2025)](#2252025---decision-engine-design)
+22. [Project Structure and Technology (2/25/2025)](#2252025---project-structure-and-technology-choices)
+23. [Begin Implementation Phase (2/25/2025)](#2252025---begin-implementation-phase)
+24. [Memory Bank Initialization (2/25/2025)](#2252025---memory-bank-initialization)
+
+## 2/27/2025 - Free Model Benchmarking Improvements
+
+**Context:** The initial implementation of free model benchmarking had several limitations: it only tested a small number of models, didn't verify if the code actually worked, and prioritized well-known providers over potentially better but lesser-known models.
+
+**Decision:** Enhance the benchmarkFreeModels method with better code quality assessment, working code verification, and a fair model selection approach that ensures all free models get benchmarked eventually.
+
+**Rationale:**
+- Benchmarking only a few models might miss high-quality free models from lesser-known providers
+- Simply checking if a response contains code isn't sufficient; we need to verify if the code actually works
+- A more sophisticated quality assessment can better differentiate between models
+- Rate limiting protection is necessary to avoid API bans when benchmarking multiple models
+- Automatically checking for unbenchmarked models ensures we continuously improve our model database
+
+**Implementation:**
+- Added code checks to verify if models produce working code (e.g., factorial function actually calculates factorials)
+- Implemented a more sophisticated evaluateQuality method with checks for code blocks, programming constructs, explanations, and comments
+- Created a benchmark-free-models.js script to run the benchmarking process
+- Added rate limiting protection with delays between API calls (5 seconds between tasks, 10 seconds between models)
+- Updated the decision engine to automatically check for unbenchmarked free models during initialization
+- Added environment variable support (MAX_MODELS_TO_BENCHMARK) to control how many models are benchmarked per run
+
+## 2/27/2025 - Code Quality Assessment Enhancement
+
+**Context:** The existing evaluateQuality method in the openRouterModule was too simplistic, only checking for the presence of code and not evaluating its quality or correctness.
+
+**Decision:** Implement a more sophisticated code quality assessment method that evaluates multiple aspects of code quality and provides a more accurate quality score.
+
+**Rationale:**
+- Simply checking if a response contains code isn't sufficient for evaluating model performance
+- Different types of tasks (coding vs. non-coding) require different evaluation criteria
+- Code quality includes factors like proper structure, comments, explanations, and programming constructs
+- A more accurate quality assessment leads to better model selection decisions
+- Penalizing very short responses helps filter out models that don't provide substantial answers
+
+**Implementation:**
+- Enhanced the evaluateQuality method with checks for:
+  - Code blocks (markdown or other formats)
+  - Common programming constructs (return statements, conditionals, loops, imports, function calls)
+  - Explanations of code functionality and complexity
+  - Code comments
+  - Response length relative to task length
+  - Response structure (paragraphs, bullet points, etc.)
+- Implemented different scoring strategies for coding vs. non-coding tasks
+- Added penalties for very short responses
+- Ensured the quality score is normalized between 0 and 1 for consistent comparison
+
+## 2/27/2025 - Fair Model Selection Approach
+
+**Context:** The initial implementation prioritized models from well-known providers (Google, Meta, Mistral, etc.) over potentially better but lesser-known models, which could lead to missing high-quality free models.
+
+**Decision:** Implement a fair model selection approach that ensures all free models get benchmarked eventually, without prioritizing based on provider name.
+
+**Rationale:**
+- Prioritizing well-known providers might miss high-quality free models from lesser-known providers
+- All free models should have a fair chance to demonstrate their capabilities
+- Benchmarking should be based on objective criteria, not provider reputation
+- Once all models have been benchmarked, we can prioritize based on actual performance data
+- This approach ensures we continuously improve our model database with comprehensive data
+
+**Implementation:**
+- Modified the model selection approach to prioritize unbenchmarked models first
+- Added tracking of benchmark counts to identify models with the fewest benchmarks
+- Implemented a system that selects models based on benchmark count rather than provider name
+- Added detailed logging about the model selection process
+- Created a fallback mechanism to ensure we always have models to benchmark
+- Added environment variable support to control how many models are benchmarked per run
+- Implemented provider categorization for better organization of free models in logs
+
+## 2/26/2025 - OpenRouter Free Model Testing
+
+**Context:** After implementing the OpenRouter integration to provide access to free models as a cost-saving option, we needed to test this functionality to ensure it works correctly. We needed to verify that the system can identify free models from OpenRouter, expose them through MCP resources, and consider them in the decision engine when routing tasks.
+
+**Decision:** Create test scripts to verify the OpenRouter free model functionality and test the integration with the decision engine.
+
+**Rationale:**
+- Testing is essential to ensure the OpenRouter integration works as expected
+- Free models can provide significant cost savings for appropriate tasks
+- The decision engine needs to consider OpenRouter models when routing tasks
+- Proper error handling is needed for cases where OpenRouter API is unavailable or no free models are available
+
+**Implementation:**
+- Created test scripts to query OpenRouter for available models
+- Tested the ability to identify free models (those with "free" in their name)
+- Verified that the system can identify and use low-cost models as an alternative when no free models are available
+- Tested the MCP resources for accessing OpenRouter model information
+- Confirmed that the decision engine correctly considers OpenRouter models when routing tasks
+- Identified areas for improvement in error handling and fallback mechanisms
+
+## 2/26/2025 - TypeScript Error Fixes in API Integration Tools
+
+**Context:** During code review, we identified TypeScript errors in the API integration tools.ts file where parameter types were incorrectly defined as strings instead of numbers. These errors needed to be fixed to ensure type safety and proper functionality of the API integration tools.
+
+**Decision:** Fix the TypeScript errors in the API integration tools.ts file by correcting parameter types and adding proper type annotations.
+
+**Rationale:**
+- Type safety is critical for preventing runtime errors and ensuring code reliability
+- Consistent parameter types across the codebase improve maintainability
+- Proper type annotations make the code more self-documenting
+- Clear comments help future developers understand the purpose of each parameter
+- Ensuring the API integration tools function correctly is essential for the overall system
+
+**Implementation:**
+- Corrected parameter types for context_length, expected_output_length, and complexity from string to number
+- Added proper type annotations with comments for clarity (e.g., "// Corrected type")
+- Ensured consistent type handling across all tool implementations
+- Verified the API integration tools functionality is intact with no errors
+- Updated Memory Bank documentation to reflect the fixes
+
+## 2/26/2025 - OpenRouter Integration
+
+**Context:** The project needed to query OpenRouter for free models and add them to the decision framework as a cost-saving possibility. This would allow users to take advantage of free models when available, potentially reducing costs while still providing good results for appropriate tasks.
+
+**Decision:** Implement a comprehensive OpenRouter module that can:
+1. Query OpenRouter for available models
+2. Track free models
+3. Handle errors from OpenRouter
+4. Determine the best prompting strategy for each model
+5. Benchmark prompting strategies
+
+**Rationale:**
+- Free models from OpenRouter can provide significant cost savings
+- Different models may require different prompting strategies for optimal results
+- Error handling is important for reliability, especially with external APIs
+- Benchmarking helps determine the best model and prompting strategy for each task
+- Integrating free models into the decision framework provides more options for cost-sensitive users
+
+**Implementation:**
+- Created a new OpenRouter module with types and implementation
+- Updated cost monitor to include OpenRouter models in available models list
+- Enhanced decision engine to consider free models when making routing decisions
+- Updated benchmark module to support benchmarking OpenRouter models
+- Added API integration tools to expose OpenRouter functionality
+- Used a helper function to check if OpenRouter API key is configured
+- Added error handling for rate limiting and other API errors
+
+## 2/26/2025 - Security and Organization Improvements
+
+**Context:** The project contains sensitive data like API keys and a large number of benchmark result files that needed to be properly managed to ensure security and maintainability.
+
+**Decision:** Implement comprehensive security measures and organization tools to protect sensitive data and improve project structure.
+
+**Rationale:**
+- API keys and other credentials should never be committed to public repositories
+- A well-structured project is easier to maintain and understand
+- Benchmark results provide valuable insights but need to be organized effectively
+- Clear documentation about security practices helps contributors follow best practices
+
+**Implementation:**
+- Enhanced the .gitignore file with more comprehensive patterns to prevent sensitive data from being committed
+- Created a proper .env.example template without actual API keys
+- Added a script (organize-benchmark-results.js) to organize benchmark results into subdirectories
+- Updated README.md with information about benchmark results and security considerations
+- Added new npm scripts for running benchmarks and organizing results
+- Documented security improvements in Memory Bank
+
+## 2/26/2025 - Version Management Policy
+
+**Context:** After completing several major components and features, we needed to establish a clear versioning policy for the project.
+
+**Decision:** Implement a consistent version management approach where the version number is updated with each task completion, following standard semantic versioning rules.
+
+**Rationale:**
+- Regular version updates provide a clear history of project progress
+- Following semantic versioning (MAJOR.MINOR.PATCH) allows for clear communication about the nature of changes:
+  - MAJOR: Breaking changes
+  - MINOR: New features, no breaking changes
+  - PATCH: Bug fixes, no new features or breaking changes
+- Updating the version with each task completion ensures we maintain an accurate record of project evolution
+- Version history helps with tracking when specific features or fixes were implemented
+
+**Implementation:**
+- Updated version from 1.0.0 to 1.2.5 to reflect current project progress
+- Added versioning policy to activeContext.md
+- Will update package.json and package-lock.json version number with each task completion going forward
+- Will document version changes in the Memory Bank
+
+## 2/26/2025 - OpenRouter Resources Exposure
+
+**Context:** After implementing the OpenRouter module to query for free models and integrate them into the decision framework, we needed to expose these resources to MCP clients. This would allow clients to access information about available OpenRouter models, free models, and prompting strategies.
+
+**Decision:** Update the resources.ts file to expose OpenRouter resources and resource templates, and implement handlers for these resources.
+
+**Rationale:**
+- Exposing OpenRouter resources through the MCP server allows clients to access information about available models
+- Resource templates provide a way to access model-specific details and prompting strategies
+- Proper error handling ensures reliability when OpenRouter API is not configured or unavailable
+- Testing the resources ensures they work correctly before deployment
+
+**Implementation:**
+- Added OpenRouter static resources:
+  - locallama://openrouter/models - List of available models from OpenRouter
+  - locallama://openrouter/free-models - List of free models available from OpenRouter
+  - locallama://openrouter/status - Status of the OpenRouter integration
+- Added OpenRouter resource templates:
+  - locallama://openrouter/model/{modelId} - Details about a specific OpenRouter model
+  - locallama://openrouter/prompting-strategy/{modelId} - Prompting strategy for a specific OpenRouter model
+- Updated resource handlers to handle these resources
+- Added proper error handling for cases where OpenRouter API key is not configured
+- Created a test script to verify the functionality of all OpenRouter resources
+- Successfully tested all resources and resource templates
+
+## 2/26/2025 - Code Cleanup and Bug Fixes
+
+**Context:** During code review, we identified an issue in the decision-engine's index.ts file where there was duplicated code causing TypeScript errors. This needed to be fixed to ensure the proper functioning of the decision engine.
+
+**Decision:** Remove the duplicated code in the decision-engine's index.ts file to fix the TypeScript errors.
+
+**Rationale:**
+- Duplicated code can lead to maintenance issues and unexpected behavior
+- TypeScript errors indicate potential runtime issues that could affect the reliability of the decision engine
+- Clean code is essential for maintainability and future development
+- Ensuring the decision engine functions correctly is critical for the overall system
+
+**Implementation:**
+- Identified the duplicated code in the decision-engine's index.ts file
+- Found that the file had a complete implementation of the decisionEngine object that ended at line 652
+- Discovered that starting at line 653, there was duplicated code from the updateModelPerformanceProfiles method, followed by complete duplicates of the preemptiveRouting and routeTask methods
+- Removed the duplicated code, keeping only the properly structured implementation
+- Verified that the file structure was correct with proper implementation of all methods
+- Confirmed that the decision engine functionality remained intact with no errors
+
+## 2/26/2025 - Preemptive Decision Framework Implementation
+
+**Context:** The existing decision engine makes API calls to get cost estimates and available models before making a routing decision, which can add latency. Based on benchmark results, we identified patterns that could enable faster decision-making without these API calls.
+
+**Decision:** Implement a preemptive decision framework that can make routing decisions at task initialization without making API calls.
+
+**Rationale:**
+- API calls to get cost estimates and available models add latency to the decision process
+- Benchmark results show clear patterns in model performance based on task complexity and token count
+- Many routing decisions can be made with high confidence based on these patterns alone
+- Eliminating redundant cost-comparison queries improves system efficiency
+- Users benefit from faster response times for straightforward routing decisions
+
+**Implementation:**
+- Added a preemptiveRouting function to the decision engine that makes decisions based on task characteristics without API calls
+- Defined complexity thresholds (SIMPLE: 0.3, MEDIUM: 0.6, COMPLEX: 0.8) based on benchmark results
+- Defined token thresholds (SMALL: 500, MEDIUM: 2000, LARGE: 8000) for context size categorization
+- Created model performance profiles with data from benchmark results
+- Added a preemptive flag to the route_task tool to optionally use preemptive routing
+- Created a dedicated preemptive_route_task tool for explicit preemptive routing
+- Modified the main routeTask function to first attempt a preemptive decision and only make API calls if confidence is low
+- Updated the API integration tools to expose the new preemptive routing capabilities
+
+## 2/26/2025 - Comprehensive Benchmark Execution
+
+**Context:** After implementing the comprehensive benchmarking system, we needed to run actual benchmarks to evaluate the performance of local LLM models against paid API models.
+
+**Decision:** Execute comprehensive benchmarks using the run-benchmarks.js script with the "comprehensive" mode.
+
+**Rationale:**
+- Running comprehensive benchmarks provides concrete data on model performance
+- Comparing multiple models helps identify the best options for different types of tasks
+- Benchmark results can be used to refine the decision engine's routing logic
+- Understanding the performance characteristics of different models is essential for making informed routing decisions
+
+**Implementation:**
+- Built the project using npm run build
+- Executed comprehensive benchmarking using node run-benchmarks.js comprehensive
+- Benchmarked qwen2.5-coder-3b-instruct against multiple paid models:
+  - gpt-3.5-turbo
+  - gpt-4o
+  - claude-3-sonnet-20240229
+  - gemini-1.5-pro
+  - mistral-large-latest
+- Generated benchmark reports and summary files
+- Analyzed benchmark results showing local model performance:
+  - Average response time: ~7000ms
+  - Success rate: 100%
+  - Quality score: 0.85
+- Identified connection issues with Ollama service that need to be addressed
+- Created benchmark result files for all task types (simple, medium, complex)
+
+## 2/25/2025 - Memory Bank Initialization
+
+**Context:** Project initialization requires a structured approach to documentation and planning.
+
+**Decision:** Implemented a Memory Bank system with core files: productContext.md, activeContext.md, progress.md, and decisionLog.md.
+
+**Rationale:** The Memory Bank system provides a structured way to maintain project context, track progress, and document decisions. This will help maintain continuity throughout the development process and serve as documentation for future contributors.
+
+**Implementation:** Created the four core Memory Bank files with initial content based on the project overview.
+
+## Template for Future Decisions
+
+## 2026-04-24 - Roadmap and Multi-Author Memory
+
+**Context:** The project is being revived after a long pause. Existing documentation still framed the server around Cline/Roo usage, and memory files described the 2025 direction rather than the current modernization effort.
+
+**Decision:** Use `docs/ROADMAP.md` as the active roadmap and implementation plan, and formalize `memory-bank/` as append-friendly multi-author project memory for humans and coding agents.
+
+**Rationale:** The revival touches documentation, MCP compatibility, provider abstractions, routing, benchmarking, and developer workflow. A roadmap keeps the work coordinated, while shared memory lets future contributors recover context without relying on a single conversation.
+
+**Implementation:** Added `docs/ROADMAP.md`, rewrote `AGENTS.md`, made `CLAUDE.md` defer to shared guidance, added `memory-bank/README.md`, added `memory-bank/sessionLog.md`, and refreshed active/product/progress memory files for the 2026 direction.
+
+```
+## [Date] - [Decision Topic]
+
+**Context:** [What led to this decision]
+
+**Decision:** [What was decided]
+
+**Rationale:** [Why this decision was made]
+
+**Implementation:** [How it will be/was implemented]

--- a/memory-bank/decisionLog.md
+++ b/memory-bank/decisionLog.md
@@ -324,6 +324,20 @@ This document tracks key architectural and technical decisions made throughout t
 
 **Implementation:** Added `docs/ROADMAP.md`, rewrote `AGENTS.md`, made `CLAUDE.md` defer to shared guidance, added `memory-bank/README.md`, added `memory-bank/sessionLog.md`, and refreshed active/product/progress memory files for the 2026 direction.
 
+## 2026-05-18 — Self-Update Strategy
+
+**Decision:** Use git SHA comparison (local `git rev-parse HEAD` vs GitHub API `/commits/future-testing`) rather than semver/npm-registry check.
+
+**Rationale:** Project tracks a branch (`future-testing`), not published releases. SHA comparison detects any commit, not just tagged versions.
+
+**Trade-off:** Requires `git` on PATH in the runtime environment. Silent skip if git unavailable.
+
+## 2026-05-18 — MCP Registration Location
+
+**Decision:** Register MCP via `claude mcp add --scope user`, not by editing settings.json directly.
+
+**Rationale:** Claude Code's settings.json schema validator rejects `mcpServers` field. The correct user-level MCP config location is `~/.claude.json`, which `claude mcp add` writes automatically.
+
 ```
 ## [Date] - [Decision Topic]
 

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -1,0 +1,61 @@
+# Product Context
+
+Last updated: 2026-04-24
+
+## Project Overview
+
+LocalLama MCP is a Model Context Protocol server for local-first coding-agent workflows. It helps an MCP-capable agent decide when to use local models, free or low-cost remote models, or paid frontier models for coding tasks.
+
+The revived product direction is provider-neutral and client-neutral. It should work well with current coding-agent tools such as Codex, Claude Code, Claw Code, Cursor, GitHub Copilot Agent mode, and generic MCP clients.
+
+## Objectives
+
+- Reduce cost by routing simple or repetitive work to capable local or free models.
+- Preserve quality by routing complex, risky, or broad-context work to stronger models.
+- Use benchmark history and live capability metadata instead of stale hardcoded model assumptions.
+- Provide useful MCP resources for model status, active jobs, cost estimates, benchmark results, and routing explanations.
+- Make model evaluation executable where possible by applying patches and running tests.
+
+## Key Components
+
+### MCP Integration
+
+- Exposes tools and resources through MCP.
+- Should remain safe for model-controlled use.
+- Should support clear setup instructions for modern MCP clients.
+
+### Provider Layer
+
+- Supports local providers such as LM Studio and Ollama.
+- Supports OpenRouter for free, low-cost, and paid models.
+- Should grow toward a common provider contract for model listing, inference, pricing, and capabilities.
+
+### Decision Engine
+
+- Analyzes tasks, estimates context and complexity, and selects models.
+- Should move from model-name heuristics to measured performance, discovered capabilities, and benchmark data.
+- Should explain routing decisions in a way users and agents can audit.
+
+### Benchmarking System
+
+- Compares models by latency, cost, token usage, output quality, and reliability.
+- Should move away from simulated paid-model results.
+- Should prioritize executable outcomes, such as tests passing after an applied patch.
+
+### Cost and Token Monitoring
+
+- Tracks token usage, cost estimates, cache behavior, and available model pricing.
+- Should support modern token accounting and provider-specific pricing metadata.
+
+### Code Search
+
+- Existing code search integrates Python/Retriv and BM25-style search.
+- Future work should decide whether Retriv remains the default or becomes an optional backend.
+
+## Product Principles
+
+- Local-first, not local-only.
+- Provider-neutral, not model-brand-specific.
+- Benchmarks should measure work that matters to coding agents.
+- Documentation should serve both humans and agents.
+- Shared project memory should be updated as work happens.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,0 +1,40 @@
+# Project Progress
+
+Last updated: 2026-04-24
+
+## 2026-04-24 Revival Work
+
+### Completed
+
+- Added `docs/ROADMAP.md` as the modernization and implementation plan.
+- Rewrote `AGENTS.md` as the shared agent-neutral operating guide.
+- Replaced `CLAUDE.md` with a small Claude Code pointer to shared guidance.
+- Added `memory-bank/README.md` with multi-author memory conventions.
+- Added `memory-bank/sessionLog.md` and a first dated session entry.
+- Updated `memory-bank/activeContext.md` with current direction and known baseline issues.
+- Updated `memory-bank/productContext.md` with the revived product framing.
+- Updated README opening and MCP client setup sections for modern agent clients.
+- Updated `.gitignore` so `memory-bank/` and `CLAUDE.md` can be tracked as shared project docs.
+
+### Verified
+
+- `npx tsc --project tsconfig.json --noEmit` succeeds.
+- `npm run build` currently fails on native Windows because the package script uses Unix `cp`.
+- `npm run lint` currently fails because `eslint-plugin-import` is missing.
+
+## Roadmap Status
+
+- Phase 0: Documentation and Shared Memory - in progress
+- Phase 1: Restore Developer Workflow - pending
+- Phase 2: MCP Surface Modernization - pending
+- Phase 3: Provider Abstraction - pending
+- Phase 4: Benchmarking Rebuild - pending
+- Phase 5: Task Understanding and Routing - pending
+- Phase 6: Documentation, Examples, and Release Prep - pending
+
+## Next Steps
+
+- Fix the cross-platform build script.
+- Fix lint dependency/configuration drift.
+- Restore or replace benchmark npm entrypoints.
+- Audit MCP tool definitions and result shapes.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -38,3 +38,16 @@ Last updated: 2026-04-24
 - Fix lint dependency/configuration drift.
 - Restore or replace benchmark npm entrypoints.
 - Audit MCP tool definitions and result shapes.
+
+## 2026-05-18 — MCP Install & Self-Update
+
+- Fixed Windows build script (Unix cp → Node inline copy) in package.json
+- Fixed dev script same way
+- Added `src/modules/updater/index.ts` with `getLocalSha`, `getRemoteSha`, `checkForUpdates`, `runUpdate`, `runStartupCheck`
+- Registered `check_for_updates` and `update_server` MCP tools in tool-definition/index.ts
+- Wired both tools into tool call handler switch in src/index.ts
+- Added fire-and-forget startup update check after server.connect()
+- Cloned future-testing branch to C:\Users\herat\.claude\mcp-servers\locallama-mcp
+- Registered server in Claude Code via `claude mcp add --scope user` (config goes to ~/.claude.json, not settings.json)
+- Server confirmed Connected via `claude mcp list`
+- Note: self-update code is on worktree branch claude/cool-satoshi-e7371b, not yet merged to future-testing

--- a/memory-bank/sessionLog.md
+++ b/memory-bank/sessionLog.md
@@ -1,0 +1,23 @@
+# Session Log
+
+## 2026-04-24 - Documentation Revival
+
+Author: Codex
+
+Summary:
+- Reframed the project as a local-first, provider-neutral MCP server for modern coding agents.
+- Added `docs/ROADMAP.md` as the shared modernization and implementation plan.
+- Updated `AGENTS.md` to be agent-neutral and to reference shared memory.
+- Replaced `CLAUDE.md` with a thin pointer to shared project guidance.
+- Added `memory-bank/README.md` with multi-author memory rules.
+- Updated the README opening and MCP client setup sections for current agent clients.
+- Updated `.gitignore` so `memory-bank/` and `CLAUDE.md` can be versioned as shared documentation.
+
+Verification:
+- Read existing docs and memory-bank files.
+- Confirmed `npx tsc --project tsconfig.json --noEmit` succeeds.
+- Confirmed known broken commands: `npm run build` fails on native Windows due to Unix `cp`; `npm run lint` fails because `eslint-plugin-import` is missing; benchmark scripts reference a missing `run-benchmarks.js`.
+
+Follow-ups:
+- Fix cross-platform build and lint dependency drift.
+- Restore or replace benchmark entrypoints.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json && node -e \"const fs=require('fs');fs.mkdirSync('dist/utils',{recursive:true});fs.copyFileSync('src/utils/lock-file.js','dist/utils/lock-file.js');\"",
     "start": "node dist/index.js",
-    "dev": "tsc -w & (cp -r src/utils/lock-file.js dist/utils/ && node --watch dist/index.js)",
+    "dev": "tsc -w & (node -e \"const fs=require('fs');fs.mkdirSync('dist/utils',{recursive:true});fs.copyFileSync('src/utils/lock-file.js','dist/utils/lock-file.js');\" && node --watch dist/index.js)",
     "test": "npm run build && NODE_OPTIONS=--experimental-vm-modules npx jest --config=jest.config.mjs",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules npx jest --config=jest.config.mjs --watch",
     "lint": "eslint src/**/*.ts test/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
-    "build": "tsc --project tsconfig.json && cp -r src/utils/lock-file.js dist/utils/",
+    "build": "tsc --project tsconfig.json && node -e \"const fs=require('fs');fs.mkdirSync('dist/utils',{recursive:true});fs.copyFileSync('src/utils/lock-file.js','dist/utils/lock-file.js');\"",
     "start": "node dist/index.js",
     "dev": "tsc -w & (cp -r src/utils/lock-file.js dist/utils/ && node --watch dist/index.js)",
     "test": "npm run build && NODE_OPTIONS=--experimental-vm-modules npx jest --config=jest.config.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import type { OpenRouterBenchmarkConfig } from './modules/api-integration/openro
 import { createLockFile, isLockFilePresent, removeLockFile, getLockFileInfo } from './utils/lock-file.js';
 import type { LockFileInfo } from './utils/lock-file.js';
 import { setClientHints } from './modules/core/client/hints.js';
+import { checkForUpdates, runUpdate, runStartupCheck } from './modules/updater/index.js';
 
 // Get the current file's directory path in ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -308,6 +309,14 @@ export class LocalLamaMcpServer {
                   const integration = new RetrivIntegration();
                   return await integration.search(query, limit);
                 }
+                case 'check_for_updates': {
+                  const updateCheck = await checkForUpdates();
+                  return JSON.stringify(updateCheck);
+                }
+                case 'update_server': {
+                  const updateResult = await runUpdate();
+                  return JSON.stringify(updateResult);
+                }
                 default:
                   logger.error(`Unknown tool: ${name}`);
                   throw new Error(`Unknown tool: ${name}`);
@@ -478,6 +487,8 @@ export class LocalLamaMcpServer {
       }
 
       logger.info(`${connectionInfo} (PID: ${process.pid})`);
+      // Fire-and-forget startup update check — never blocks startup
+      runStartupCheck().catch(() => undefined);
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.error('Server initialization failed:', errorMessage);

--- a/src/modules/api-integration/tool-definition/index.ts
+++ b/src/modules/api-integration/tool-definition/index.ts
@@ -546,7 +546,28 @@ class ToolDefinitionProvider implements IToolDefinitionProvider {
         }
       );
     }
-    
+
+    tools.push(
+      {
+        name: 'check_for_updates',
+        description: 'Check whether the running locallama-mcp server is up to date with the latest commit on the future-testing branch on GitHub. Returns upToDate status, local SHA, remote SHA, and any error.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: []
+        }
+      },
+      {
+        name: 'update_server',
+        description: 'Pull the latest changes from GitHub and rebuild the server. Runs git pull, npm install, and npm run build in sequence. IMPORTANT: The server must be manually restarted after this completes for changes to take effect.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: []
+        }
+      }
+    );
+
     return tools;
   }
 }

--- a/src/modules/updater/index.ts
+++ b/src/modules/updater/index.ts
@@ -1,0 +1,131 @@
+import { execSync } from 'child_process';
+import https from 'https';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { logger } from '../../utils/logger.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+// Resolve install root: dist/modules/updater -> project root
+const INSTALL_ROOT = join(__dirname, '../../..');
+
+const GITHUB_API_URL = 'https://api.github.com/repos/Heratiki/locallama-mcp/commits/future-testing';
+
+export interface UpdateCheckResult {
+  upToDate: boolean | null;
+  localSha: string | null;
+  remoteSha: string | null;
+  error?: string;
+}
+
+export interface UpdateResult {
+  success: boolean;
+  completedSteps: string[];
+  failedStep?: string;
+  error?: string;
+  restartRequired: boolean;
+}
+
+export async function getLocalSha(): Promise<string | null> {
+  try {
+    const output = execSync('git rev-parse HEAD', {
+      cwd: INSTALL_ROOT,
+      stdio: 'pipe',
+    });
+    return output.toString().trim();
+  } catch {
+    return null;
+  }
+}
+
+export async function getRemoteSha(): Promise<string | null> {
+  return new Promise((resolve) => {
+    const req = https.get(
+      GITHUB_API_URL,
+      { headers: { 'User-Agent': 'locallama-mcp-updater' } },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+        res.on('end', () => {
+          try {
+            const parsed = JSON.parse(data) as { sha?: string };
+            resolve(parsed.sha ?? null);
+          } catch {
+            resolve(null);
+          }
+        });
+      }
+    );
+    req.on('error', () => resolve(null));
+    req.setTimeout(5000, () => { req.destroy(); resolve(null); });
+  });
+}
+
+export async function checkForUpdates(): Promise<UpdateCheckResult> {
+  try {
+    const [localSha, remoteSha] = await Promise.all([getLocalSha(), getRemoteSha()]);
+    if (localSha === null || remoteSha === null) {
+      return {
+        upToDate: null,
+        localSha,
+        remoteSha,
+        error: localSha === null ? 'Could not read local git SHA' : 'Could not reach GitHub API',
+      };
+    }
+    return { upToDate: localSha === remoteSha, localSha, remoteSha };
+  } catch (err) {
+    return {
+      upToDate: null,
+      localSha: null,
+      remoteSha: null,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export async function runUpdate(): Promise<UpdateResult> {
+  const completedSteps: string[] = [];
+  const steps: Array<{ name: string; cmd: string }> = [
+    { name: 'git pull', cmd: 'git pull' },
+    { name: 'npm install', cmd: 'npm install' },
+    { name: 'npm run build', cmd: 'npm run build' },
+  ];
+
+  for (const step of steps) {
+    try {
+      execSync(step.cmd, { cwd: INSTALL_ROOT, stdio: 'pipe' });
+      completedSteps.push(step.name);
+    } catch (err) {
+      return {
+        success: false,
+        completedSteps,
+        failedStep: step.name,
+        error: err instanceof Error ? err.message : String(err),
+        restartRequired: false,
+      };
+    }
+  }
+
+  return {
+    success: true,
+    completedSteps,
+    restartRequired: true,
+  };
+}
+
+export async function runStartupCheck(): Promise<void> {
+  try {
+    const localSha = await getLocalSha();
+    if (localSha === null) return; // not a git install, skip silently
+    const remoteSha = await getRemoteSha();
+    if (remoteSha === null) return; // network unavailable, skip silently
+    if (localSha !== remoteSha) {
+      logger.warn(
+        `locallama-mcp update available. Remote: ${remoteSha.slice(0, 7)}, Local: ${localSha.slice(0, 7)}. ` +
+        `Call the check_for_updates or update_server tool to apply.`
+      );
+    }
+  } catch {
+    // never throw on startup
+  }
+}

--- a/src/modules/updater/index.ts
+++ b/src/modules/updater/index.ts
@@ -26,15 +26,15 @@ export interface UpdateResult {
   restartRequired: boolean;
 }
 
-export async function getLocalSha(): Promise<string | null> {
+export function getLocalSha(): Promise<string | null> {
   try {
     const output = execSync('git rev-parse HEAD', {
       cwd: INSTALL_ROOT,
       stdio: 'pipe',
     });
-    return output.toString().trim();
+    return Promise.resolve(output.toString().trim());
   } catch {
-    return null;
+    return Promise.resolve(null);
   }
 }
 
@@ -44,6 +44,12 @@ export async function getRemoteSha(): Promise<string | null> {
       GITHUB_API_URL,
       { headers: { 'User-Agent': 'locallama-mcp-updater' } },
       (res) => {
+        if (res.statusCode !== 200) {
+          logger.debug(`GitHub API returned status ${res.statusCode}`);
+          res.resume(); // consume response body
+          resolve(null);
+          return;
+        }
         let data = '';
         res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
         res.on('end', () => {
@@ -86,7 +92,7 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
 export async function runUpdate(): Promise<UpdateResult> {
   const completedSteps: string[] = [];
   const steps: Array<{ name: string; cmd: string }> = [
-    { name: 'git pull', cmd: 'git pull' },
+    { name: 'git pull', cmd: 'git pull origin future-testing' },
     { name: 'npm install', cmd: 'npm install' },
     { name: 'npm run build', cmd: 'npm run build' },
   ];
@@ -96,11 +102,14 @@ export async function runUpdate(): Promise<UpdateResult> {
       execSync(step.cmd, { cwd: INSTALL_ROOT, stdio: 'pipe' });
       completedSteps.push(step.name);
     } catch (err) {
+      const errMessage = err instanceof Error
+        ? ((err as NodeJS.ErrnoException & { stderr?: Buffer }).stderr?.toString().trim() ?? err.message)
+        : String(err);
       return {
         success: false,
         completedSteps,
         failedStep: step.name,
-        error: err instanceof Error ? err.message : String(err),
+        error: errMessage,
         restartRequired: false,
       };
     }

--- a/test/modules/updater/index.test.ts
+++ b/test/modules/updater/index.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+
+// We test the pure logic; shell/network calls are mocked.
+jest.mock('child_process');
+jest.mock('https');
+
+import { execSync } from 'child_process';
+import * as https from 'https';
+
+const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+
+describe('getLocalSha', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  it('returns trimmed SHA string when git succeeds', async () => {
+    mockExecSync.mockReturnValue(Buffer.from('abc1234\n'));
+    const { getLocalSha } = await import('../../../dist/modules/updater/index.js');
+    const sha = await getLocalSha();
+    expect(sha).toBe('abc1234');
+  });
+
+  it('returns null when git is not available', async () => {
+    mockExecSync.mockImplementation(() => { throw new Error('git not found'); });
+    const { getLocalSha } = await import('../../../dist/modules/updater/index.js');
+    const sha = await getLocalSha();
+    expect(sha).toBeNull();
+  });
+});
+
+describe('checkForUpdates', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  it('returns upToDate true when SHAs match', async () => {
+    mockExecSync.mockReturnValue(Buffer.from('abc1234\n'));
+    // getRemoteSha is tested via integration; mock it at module boundary
+    const updater = await import('../../../dist/modules/updater/index.js');
+    jest.spyOn(updater, 'getRemoteSha').mockResolvedValue('abc1234');
+    const result = await updater.checkForUpdates();
+    expect(result.upToDate).toBe(true);
+    expect(result.localSha).toBe('abc1234');
+    expect(result.remoteSha).toBe('abc1234');
+  });
+
+  it('returns upToDate false when SHAs differ', async () => {
+    mockExecSync.mockReturnValue(Buffer.from('abc1234\n'));
+    const updater = await import('../../../dist/modules/updater/index.js');
+    jest.spyOn(updater, 'getRemoteSha').mockResolvedValue('def5678');
+    const result = await updater.checkForUpdates();
+    expect(result.upToDate).toBe(false);
+  });
+
+  it('returns upToDate null on error', async () => {
+    mockExecSync.mockImplementation(() => { throw new Error('git not found'); });
+    const updater = await import('../../../dist/modules/updater/index.js');
+    jest.spyOn(updater, 'getRemoteSha').mockRejectedValue(new Error('network'));
+    const result = await updater.checkForUpdates();
+    expect(result.upToDate).toBeNull();
+    expect(result.error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Fix cross-platform Windows build script (`cp -r` → Node.js `fs.copyFileSync`) in both `build` and `dev` npm scripts
- Add `src/modules/updater/index.ts` — standalone module with `getLocalSha`, `getRemoteSha`, `checkForUpdates`, `runUpdate`, `runStartupCheck`
- Register two new MCP tools: `check_for_updates` (compares local git SHA to GitHub `future-testing` branch) and `update_server` (runs `git pull origin future-testing && npm install && npm run build`)
- Add fire-and-forget startup update check — logs warning if server is behind, never blocks startup
- Update memory bank with decisions and progress

## Test Plan

- [ ] TypeScript compiles clean (`npx tsc --project tsconfig.json --noEmit`)
- [ ] `npm run build` succeeds on Windows
- [ ] Call `check_for_updates` tool — returns `{upToDate, localSha, remoteSha}`
- [ ] After merging, clone `future-testing` to `~/.claude/mcp-servers/locallama-mcp`, build, run `claude mcp add --scope user locallama-mcp -- node "C:\Users\herat\.claude\mcp-servers\locallama-mcp\dist\index.js"`, verify Connected
- [ ] Call `update_server` tool — returns `{success: true, completedSteps: [...], restartRequired: true}`

## Notes

- Updater tests in `test/modules/updater/index.test.ts` fail due to ESM+Jest mocking limitation (documented in spec). Pre-existing test failures (6 suites) are unrelated to this PR.
- After merge, the installed clone at `~/.claude/mcp-servers/locallama-mcp` should run `git pull && npm install && npm run build` to get this new code (or call the `update_server` tool once it's available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)