### PR TITLE
Issue 20: provider timeout fallback + structured timeout errors + v1.14.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ PYTHON_DETECT_VENV=true
   - `LM_STUDIO_ENDPOINT`: URL where your LM Studio instance is running
   - `OLLAMA_ENDPOINT`: URL where your Ollama instance is running
   - `OLLAMA_TIMEOUT`: Per-request Ollama timeout in milliseconds (default `120000`)
+  - `PROVIDER_TIMEOUT_MS`: Generic per-request timeout in milliseconds for providers without a specific override (default `120000`)
 
 - **Configuration**
   - `DEFAULT_LOCAL_MODEL`: The local LLM model to use when offloading tasks

--- a/docs/OPERATIONAL_TEST_PLAN.md
+++ b/docs/OPERATIONAL_TEST_PLAN.md
@@ -304,6 +304,7 @@ No test verifies what happens at the MCP tool-call timeout boundary. Currently, 
 - Invoke `route_task` against a model that is known to be too large for available hardware and assert that the response is a structured error (not a hang or a connection reset).
 - Verify that `ERR_CANCELED` from Ollama maps to a user-readable error message, not `"Error executing task: unknown"`.
 - Assert that `OLLAMA_TIMEOUT` is respected: a task that would take longer than the configured timeout returns a timeout error within `OLLAMA_TIMEOUT + 5s`.
+- Assert that `PROVIDER_TIMEOUT_MS` applies to providers without dedicated timeout vars (LM Studio/OpenRouter), and timeout failures surface as structured `inference_timeout` responses including `timeoutMs`.
 
 **Blocker:** Requires a controllable slow-model fixture. On System A, `gemma4:26b` can serve this role for slow-inference tests, but it must be used in isolation (not in the standard suite) to avoid slowing every CI run.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "locallama-mcp",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "MCP Server for intelligently routing coding tasks between local LLMs and free or paid APIs",
   "main": "dist/index.js",
   "type": "module",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -42,6 +42,7 @@ export interface Config {
   lmStudioEndpoint: string;
   ollamaEndpoint: string;
   ollamaTimeout: number;
+  providerTimeoutMs: number;
   providerMaxConcurrentLocal: number;
   providerMaxConcurrentRemote: number;
   localLlamaEndpoint: string; // Added local Llama endpoint
@@ -124,6 +125,7 @@ export const config: Config = {
   lmStudioEndpoint: process.env.LM_STUDIO_ENDPOINT || 'http://localhost:1234/v1',
   ollamaEndpoint: process.env.OLLAMA_ENDPOINT || 'http://localhost:11434/api',
   ollamaTimeout: parseInt(process.env.OLLAMA_TIMEOUT || '120000', 10),
+  providerTimeoutMs: parseInt(process.env.PROVIDER_TIMEOUT_MS || '120000', 10),
   providerMaxConcurrentLocal: parseNumber(process.env.PROVIDER_MAX_CONCURRENT_LOCAL, 1, 1, 64),
   providerMaxConcurrentRemote: parseNumber(process.env.PROVIDER_MAX_CONCURRENT_REMOTE, 1, 1, 128),
   localLlamaEndpoint: process.env.LOCAL_LLAMA_ENDPOINT || 'http://localhost:12345/api', // Added local Llama endpoint
@@ -253,6 +255,9 @@ export function validateConfig(): void {
   }
   if (config.ollamaTimeout <= 0) {
     errors.push(`Invalid ollamaTimeout: ${config.ollamaTimeout}`);
+  }
+  if (config.providerTimeoutMs <= 0) {
+    errors.push(`Invalid providerTimeoutMs: ${config.providerTimeoutMs}`);
   }
   // Validate cache config
   if (config.maxCacheSize <= 0) {

--- a/src/modules/lm-studio/index.ts
+++ b/src/modules/lm-studio/index.ts
@@ -16,6 +16,7 @@ import {
   SpeculativeInferenceConfig,
   PromptImprovementConfig
 } from './types.js';
+import { InferenceTimeoutError } from '../utils/inferenceTimeout.js';
 import { getPromptingStrategyService } from '../core/prompting/service.js';
 import { buildCodeTaskExecutionOptions } from '../core/prompting/execution-profile.js';
 
@@ -155,8 +156,11 @@ export const lmStudioModule = {
             logger.error('LM Studio server error');
             return LMStudioErrorType.SERVER_ERROR;
           }
-        } else if (axiosError.code === 'ECONNREFUSED' || axiosError.code === 'ECONNABORTED') {
-          logger.error('LM Studio connection refused or timed out');
+        } else if (axiosError.code === 'ECONNABORTED' || axiosError.code === 'ERR_CANCELED') {
+          logger.error('LM Studio request timed out or was canceled');
+          return LMStudioErrorType.TIMEOUT;
+        } else if (axiosError.code === 'ECONNREFUSED') {
+          logger.error('LM Studio connection refused');
           return LMStudioErrorType.SERVER_ERROR;
         }
       } else if (error.message.includes('context length')) {
@@ -1256,8 +1260,10 @@ export const lmStudioModule = {
         throw new Error('LM Studio endpoint not configured');
       }
 
-      // Determine the execution timeout (default to 3 minutes)
-      const timeout = options?.timeoutMs && options.timeoutMs > 0 ? options.timeoutMs : 180000;
+      // Use explicit timeout when provided; otherwise fall back to global provider timeout.
+      const timeout = options?.timeoutMs && options.timeoutMs > 0
+        ? options.timeoutMs
+        : config.providerTimeoutMs;
 
       // Call the LM Studio API
       const result = await this.callLMStudioApi(
@@ -1289,6 +1295,12 @@ export const lmStudioModule = {
               throwWithDiagnostics('Context length exceeded. Please reduce the size of your task.');
             case LMStudioErrorType.MODEL_NOT_FOUND:
               throwWithDiagnostics(`Model ${modelId} not found in LM Studio.`);
+            case LMStudioErrorType.TIMEOUT:
+              throw new InferenceTimeoutError(
+                'lm-studio',
+                timeout,
+                `LM Studio inference timed out after ${timeout}ms.`,
+              );
             case LMStudioErrorType.SERVER_ERROR:
               throwWithDiagnostics('LM Studio server error. Please ensure LM Studio is running.');
             default:

--- a/src/modules/lm-studio/types.ts
+++ b/src/modules/lm-studio/types.ts
@@ -27,6 +27,7 @@ export enum LMStudioErrorType {
   AUTHENTICATION = 'authentication',
   RATE_LIMIT = 'rate_limit',
   INVALID_REQUEST = 'invalid_request',
+  TIMEOUT = 'timeout',
   CONTENT_FILTER = 'content_filter',
   CONTEXT_LENGTH_EXCEEDED = 'context_length_exceeded',
   SERVER_ERROR = 'server_error',

--- a/src/modules/openrouter/index.ts
+++ b/src/modules/openrouter/index.ts
@@ -17,6 +17,7 @@ import {
 import { speculativeDecodingService } from '../decision-engine/services/speculativeDecoding.js';
 import { getPromptingStrategyService } from '../core/prompting/service.js';
 import { buildCodeTaskExecutionOptions } from '../core/prompting/execution-profile.js';
+import { InferenceTimeoutError } from '../utils/inferenceTimeout.js';
 
 
 // Add a custom error class
@@ -669,6 +670,9 @@ export const openRouterModule = {
       } else if (axiosError.response && axiosError.response.status >= 500) {
         logger.error('OpenRouter server error');
         return OpenRouterErrorType.SERVER_ERROR;
+      } else if (axiosError.code === 'ECONNABORTED' || axiosError.code === 'ERR_CANCELED') {
+        logger.error('OpenRouter request timed out or was canceled');
+        return OpenRouterErrorType.TIMEOUT;
       }
     }
     
@@ -1266,8 +1270,10 @@ export const openRouterModule = {
         throw new Error(`Model ${normalizedModelId} is temporarily quarantined due to recent failures. Please retry later or select another model.`);
       }
       
-      // Determine the execution timeout (default to 3 minutes)
-      const timeout = options?.timeoutMs && options.timeoutMs > 0 ? options.timeoutMs : 180000;
+      // Use explicit timeout when provided; otherwise fall back to global provider timeout.
+      const timeout = options?.timeoutMs && options.timeoutMs > 0
+        ? options.timeoutMs
+        : config.providerTimeoutMs;
 
       const executionOptions = {
         ...buildCodeTaskExecutionOptions(task, 'openrouter'),
@@ -1291,6 +1297,12 @@ export const openRouterModule = {
               throw new Error('Context length exceeded. Please reduce the size of your task.');
             case OpenRouterErrorType.MODEL_NOT_FOUND:
               throw new Error(`Model ${modelId} not found in OpenRouter.`);
+            case OpenRouterErrorType.TIMEOUT:
+              throw new InferenceTimeoutError(
+                'openrouter',
+                timeout,
+                `OpenRouter inference timed out after ${timeout}ms.`,
+              );
             case OpenRouterErrorType.SERVER_ERROR:
               throw new Error('OpenRouter server error. Please try again later.');
             default:

--- a/src/modules/openrouter/types.ts
+++ b/src/modules/openrouter/types.ts
@@ -194,6 +194,9 @@ export enum OpenRouterErrorType {
   
   /** Invalid request */
   INVALID_REQUEST = 'invalid_request',
+
+  /** Request timed out */
+  TIMEOUT = 'timeout',
   
   /** Model not found */
   MODEL_NOT_FOUND = 'model_not_found',

--- a/test/config/path-root.test.ts
+++ b/test/config/path-root.test.ts
@@ -10,6 +10,7 @@ const originalCwd = process.cwd();
 const originalRootDir = process.env.LOCALLAMA_ROOT_DIR;
 const originalProviderMaxConcurrentLocal = process.env.PROVIDER_MAX_CONCURRENT_LOCAL;
 const originalProviderMaxConcurrentRemote = process.env.PROVIDER_MAX_CONCURRENT_REMOTE;
+const originalProviderTimeoutMs = process.env.PROVIDER_TIMEOUT_MS;
 
 function importFreshModule(modulePath: string, cacheKey: string) {
   const moduleUrl = new URL(`${pathToFileURL(modulePath).href}?${cacheKey}`);
@@ -35,6 +36,12 @@ afterEach(() => {
     delete process.env.PROVIDER_MAX_CONCURRENT_REMOTE;
   } else {
     process.env.PROVIDER_MAX_CONCURRENT_REMOTE = originalProviderMaxConcurrentRemote;
+  }
+
+  if (originalProviderTimeoutMs === undefined) {
+    delete process.env.PROVIDER_TIMEOUT_MS;
+  } else {
+    process.env.PROVIDER_TIMEOUT_MS = originalProviderTimeoutMs;
   }
 });
 
@@ -97,6 +104,17 @@ describe('root path resolution', () => {
     expect(configModule.config.providerMaxConcurrentRemote).toBe(1);
   });
 
+  it('defaults provider timeout fallback to 120000ms', async () => {
+    delete process.env.PROVIDER_TIMEOUT_MS;
+
+    const configModule = await importFreshModule(
+      path.resolve(originalCwd, 'dist/config/index.js'),
+      `provider-timeout-default=${randomUUID()}`
+    );
+
+    expect(configModule.config.providerTimeoutMs).toBe(120000);
+  });
+
   it('allows provider concurrency caps to be configured with env vars', async () => {
     const script = [
       "import('./dist/config/index.js').then(({ config }) => {",
@@ -123,5 +141,35 @@ describe('root path resolution', () => {
 
     expect(parsed.local).toBe(2);
     expect(parsed.remote).toBe(3);
+  });
+
+  it('allows PROVIDER_TIMEOUT_MS to override the generic provider timeout fallback', async () => {
+    const script = [
+      "import('./dist/config/index.js').then(({ config }) => {",
+      "console.log(JSON.stringify({ providerTimeoutMs: config.providerTimeoutMs }));",
+      '});',
+    ].join('');
+    const output = execFileSync(
+      process.execPath,
+      ['--input-type=module', '-e', script],
+      {
+        cwd: originalCwd,
+        env: {
+          ...process.env,
+          PROVIDER_TIMEOUT_MS: '45000',
+        },
+        encoding: 'utf8',
+      },
+    );
+
+    const jsonLine = output
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('{') && line.endsWith('}'))
+      .pop();
+
+    expect(jsonLine).toBeDefined();
+    const parsed = JSON.parse(jsonLine || '{}') as { providerTimeoutMs?: number };
+    expect(parsed.providerTimeoutMs).toBe(45000);
   });
 });

--- a/test/dispatcher.test.ts
+++ b/test/dispatcher.test.ts
@@ -345,6 +345,33 @@ describe('LocalLamaMcpServer tool dispatcher', () => {
     });
   });
 
+  it('returns a structured inference_timeout body from route_task', async () => {
+    if (!capturedHandler) throw new Error('handler not registered');
+    const { InferenceTimeoutError } = await import('../dist/modules/utils/inferenceTimeout.js');
+    mockRouteTask.mockRejectedValueOnce(
+      new InferenceTimeoutError('openrouter', 45000, 'OpenRouter inference timed out after 45000ms.'),
+    );
+
+    const result = await capturedHandler(
+      {
+        params: {
+          name: 'route_task',
+          arguments: { task: 'slow prompt', context_length: 1200 },
+        },
+      },
+      {},
+    );
+
+    const typed = result as { content: { type: string; text: string }[]; isError?: boolean };
+    expect(typed.isError).toBe(true);
+    const parsed = JSON.parse(typed.content[0].text);
+    expect(parsed).toMatchObject({
+      error: 'inference_timeout',
+      providerId: 'openrouter',
+      timeoutMs: 45000,
+    });
+  });
+
   it('routes preemptive_route_task to the routing module', async () => {
     if (!capturedHandler) throw new Error('handler not registered');
 

--- a/test/modules/ollama/timeout.test.ts
+++ b/test/modules/ollama/timeout.test.ts
@@ -50,4 +50,18 @@ describe('ollamaModule timeout handling', () => {
 
     expect(callSpy).toHaveBeenCalled();
   });
+
+  it('returns content when inference completes within timeout window', async () => {
+    const callSpy = jest.spyOn(ollamaModule, 'callOllamaApi').mockResolvedValue({
+      success: true,
+      text: 'function add(a, b) { return a + b; }',
+      usage: {
+        prompt_tokens: 12,
+        completion_tokens: 9,
+      },
+    });
+
+    await expect(ollamaModule.executeTask('gemma3n:e2b', 'Write an add function')).resolves.toContain('function add');
+    expect(callSpy).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- add generic provider timeout fallback via `PROVIDER_TIMEOUT_MS` in config (default 120000)
- route LM Studio and OpenRouter default execution timeouts to `config.providerTimeoutMs`
- classify LM Studio/OpenRouter timeout/cancel transport errors and normalize to `InferenceTimeoutError`
- add tests for timeout behavior and config timeout fallback
- update docs and bump package version to `1.14.3`

## Validation
- `npm test` passes locally (37/37 suites, 261/261 tests)

## Target
Base branch: `future-testing`