### PR TITLE
feat: wire CapabilityDetector capability-score filter into routing (#28)

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -91,6 +91,10 @@ export interface Config {
   //   preferred and paid APIs are only used for genuinely complex work.
   // 'default': standard thresholds from benchmark results.
   profile: 'default' | 'lightweight';
+
+  // Minimum empirical code-benchmark score (0..1) a model must meet to be
+  // eligible for code tasks. Models with no benchmark data are not filtered.
+  codeScoreThreshold: number;
 }
 
 /**
@@ -190,6 +194,9 @@ export const config: Config = {
   
   // Hardware profile
   profile: (process.env.LOCALLAMA_PROFILE === 'lightweight' ? 'lightweight' : 'default') as 'default' | 'lightweight',
+
+  // Code-score filter threshold — matches CapabilityDetector's own 0.3 floor
+  codeScoreThreshold: parseFloat(process.env.CODE_SCORE_THRESHOLD ?? '0.3'),
 
   // Paths
   rootDir,

--- a/src/modules/decision-engine/services/codeModelSelector.ts
+++ b/src/modules/decision-engine/services/codeModelSelector.ts
@@ -9,6 +9,7 @@ import { COMPLEXITY_THRESHOLDS } from '../types/index.js';
 import { config } from '../../../config/index.js';
 import { isProviderId, isProviderLocal, getProviderRegistry } from '../../core/provider/index.js';
 import { getModelRegistry } from '../../core/model/index.js';
+import { getCapabilityDetector } from '../../core/capability-detector.js';
 
 /**
  * Interface for the model performance tracker methods
@@ -57,34 +58,79 @@ export const codeModelSelector = {
         return this.getFallbackModel(subtask);
       }
       
-      // Filter models that can handle the token requirements
+      // Filter models that can handle the token requirements.
+      // For large prompts (≥ 32 768 tokens) prefer the largeContext capability
+      // flag from CapabilityDetector (which applies empirical corrections) and
+      // fall back to raw contextWindow only when no capability data is available.
+      const needsLargeContext = subtask.estimatedTokens >= 32768;
       const suitableModels = allModels.filter(model => {
+        if (needsLargeContext) {
+          let caps;
+          try {
+            caps = getCapabilityDetector().detectCapabilities(model.id);
+          } catch {
+            caps = getModelRegistry().getModel(model.id)?.capabilities;
+          }
+          if (caps !== undefined) {
+            return caps.largeContext;
+          }
+          // Fall back to raw contextWindow when no capability data available
+          return !model.contextWindow || model.contextWindow >= subtask.estimatedTokens;
+        }
         return !model.contextWindow || model.contextWindow >= subtask.estimatedTokens;
       });
-      
+
       if (suitableModels.length === 0) {
         logger.warn(`No models found that can handle subtask with ${subtask.estimatedTokens} tokens`);
         return this.getFallbackModel(subtask);
       }
-      
+
+      // Filter by empirical code-benchmark score. Models that have been
+      // benchmarked and scored below the threshold are excluded; models with
+      // no benchmark data pass through unchanged (not yet measured ≠ bad).
+      const scoreThreshold = config.codeScoreThreshold;
+      const passingScoreModels = suitableModels.filter(model => {
+        let caps;
+        try {
+          caps = getCapabilityDetector().detectCapabilities(model.id);
+        } catch {
+          caps = getModelRegistry().getModel(model.id)?.capabilities;
+        }
+        const codeScore = caps?.scores?.code;
+        if (codeScore !== undefined) {
+          if (codeScore < scoreThreshold) {
+            logger.debug(`Excluding ${model.id} from code routing: score ${codeScore.toFixed(2)} < threshold ${scoreThreshold}`);
+            return false;
+          }
+        }
+        return true;
+      });
+
+      // If score filtering removed every candidate, fall back to unfiltered list
+      // so a low-benchmark-score model is always preferable to no model at all.
+      const filteredModels = passingScoreModels.length > 0 ? passingScoreModels : suitableModels;
+      if (passingScoreModels.length === 0 && suitableModels.length > 0) {
+        logger.warn('All models failed code-score threshold; using unfiltered candidate list as fallback');
+      }
+
       // Log model counts by provider for debugging
-      const modelsByProvider = suitableModels.reduce((acc, model) => {
+      const modelsByProvider = filteredModels.reduce((acc, model) => {
         acc[model.provider] = (acc[model.provider] || 0) + 1;
         return acc;
       }, {} as Record<string, number>);
-      
+
       logger.debug(`Models by provider: ${JSON.stringify(modelsByProvider)}`);
-      
+
       // Get performance analysis for this complexity range
       // Use the injected reference to avoid circular dependency
       const perfAnalysis = this._modelPerformanceTracker.analyzePerformanceByComplexity(
         Math.max(0, subtask.complexity - 0.1),
         Math.min(1, subtask.complexity + 0.1)
       );
-      
-      // Score all suitable models
+
+      // Score all filtered models
       const scoredModels = await Promise.all(
-        suitableModels.map(async model => {
+        filteredModels.map(async model => {
           const score = await this.scoreModelForSubtask(model, subtask, perfAnalysis, originalTask);
           return { model, score };
         })

--- a/src/modules/decision-engine/services/taskRouter.ts
+++ b/src/modules/decision-engine/services/taskRouter.ts
@@ -7,6 +7,7 @@ import { CodeSubtask, Task } from '../types/codeTask.js';
 import TaskExecutor from './taskExecutor.js';
 import { isProviderLocal } from '../../core/provider/index.js';
 import { getModelRegistry } from '../../core/model/index.js';
+import { getCapabilityDetector } from '../../core/capability-detector.js';
 
 interface RoutingStrategy {
   name: string;
@@ -459,17 +460,24 @@ class TaskRouter {
         
         // Filter by token requirements and capability
         modelsToConsider = modelsToConsider.filter(m => {
-          const caps = getModelRegistry().getModel(m.id)?.capabilities;
+          // Use CapabilityDetector so empirical benchmark corrections (layer 3)
+          // are applied. Fall back to raw registry caps if detector unavailable.
+          let caps;
+          try {
+            caps = getCapabilityDetector().detectCapabilities(m.id);
+          } catch {
+            caps = getModelRegistry().getModel(m.id)?.capabilities;
+          }
 
-          // For tasks requiring ≥ 32 768 tokens, use the registry largeContext flag
-          // when available; fall back to raw contextWindow comparison otherwise.
+          // For tasks requiring ≥ 32 768 tokens, use the largeContext flag when
+          // available; fall back to raw contextWindow comparison otherwise.
           const needsLargeContext = maxIndividualTokens >= 32768;
           const meetsTokenReq = needsLargeContext
             ? (caps !== undefined ? caps.largeContext : (!m.contextWindow || m.contextWindow >= maxIndividualTokens))
             : (!m.contextWindow || m.contextWindow >= maxIndividualTokens);
 
-          // Check for specialized code capabilities using registry caps when
-          // available; fall back to heuristic model-name regex.
+          // Check for specialized code capabilities using empirically-corrected
+          // caps when available; fall back to heuristic model-name regex.
           if (requiresCodeCapability) {
             const hasCodeCap = caps !== undefined
               ? caps.code

--- a/test/modules/decision-engine/capability-score-filter.test.ts
+++ b/test/modules/decision-engine/capability-score-filter.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for issue #28 — capability score filter wired into codeModelSelector.
+ * Tests assert external behaviour: which model gets selected / excluded when
+ * CapabilityDetector returns scores and largeContext flags.
+ */
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+
+// ---------------------------------------------------------------------------
+// Infrastructure mocks
+// ---------------------------------------------------------------------------
+
+jest.unstable_mockModule('../../../dist/utils/logger.js', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+jest.unstable_mockModule('../../../dist/modules/cost-monitor/index.js', () => ({
+  costMonitor: {
+    getAvailableModels: jest.fn().mockResolvedValue([]),
+    getFreeModels: jest.fn().mockResolvedValue([]),
+    search: jest.fn().mockResolvedValue([]),
+  },
+  CodeSearchEngine: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../../dist/modules/openrouter/index.js', () => ({
+  openRouterModule: {
+    getFreeModels: jest.fn().mockResolvedValue([]),
+    evaluateQuality: jest.fn().mockReturnValue(0.7),
+  },
+}));
+
+jest.unstable_mockModule('../../../dist/modules/core/provider/index.js', () => ({
+  isProviderId: jest.fn().mockReturnValue(false),
+  isProviderLocal: jest.fn().mockReturnValue(true),
+  getProviderRegistry: jest.fn().mockReturnValue({ list: () => [], get: () => null }),
+}));
+
+jest.unstable_mockModule('../../../dist/modules/core/model/index.js', () => ({
+  getModelRegistry: jest.fn().mockReturnValue({ getModel: () => null }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeModel(id: string, contextWindow = 8192, provider = 'ollama') {
+  return {
+    id,
+    provider,
+    contextWindow,
+    costPerToken: { prompt: 0, completion: 0 },
+    capabilities: { chat: true, completion: true },
+    name: id,
+  };
+}
+
+function makeSubtask(estimatedTokens: number, codeType = 'function' as const) {
+  return {
+    id: 'sub-1',
+    description: 'write a function',
+    estimatedTokens,
+    complexity: 0.3,
+    codeType,
+    dependencies: [],
+    priority: 1,
+  };
+}
+
+function fakeCapabilities(overrides: Record<string, unknown> = {}) {
+  return {
+    chat: true, code: true, vision: false, toolUse: false,
+    largeContext: false, maxContextTokens: 8192,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// codeModelSelector — score-threshold filter
+// ---------------------------------------------------------------------------
+
+describe('codeModelSelector capability-score filter (issue #28)', () => {
+  let capDetectorModule: { _setCapabilityDetectorForTests: (d: unknown) => void };
+  let costMonitorMock: { getAvailableModels: ReturnType<typeof jest.fn> };
+
+  beforeEach(async () => {
+    capDetectorModule = await import('../../../dist/modules/core/capability-detector.js') as typeof capDetectorModule;
+    const costMod = await import('../../../dist/modules/cost-monitor/index.js') as { costMonitor: { getAvailableModels: ReturnType<typeof jest.fn> } };
+    costMonitorMock = costMod.costMonitor;
+  });
+
+  afterEach(() => {
+    capDetectorModule._setCapabilityDetectorForTests(undefined);
+    jest.clearAllMocks();
+  });
+
+  it('excludes model with empirical code score below threshold (0.1 < 0.3)', async () => {
+    const poorCoder = makeModel('poor-coder');
+    const goodCoder = makeModel('good-coder');
+
+    costMonitorMock.getAvailableModels.mockResolvedValue([poorCoder, goodCoder]);
+
+    const detector = {
+      detectCapabilities: (id: string) => {
+        if (id === 'poor-coder') return fakeCapabilities({ scores: { code: 0.1 } });
+        if (id === 'good-coder') return fakeCapabilities({ scores: { code: 0.9 } });
+        return fakeCapabilities();
+      },
+    };
+    capDetectorModule._setCapabilityDetectorForTests(detector);
+
+    const configMod = await import('../../../dist/config/index.js') as { config: Record<string, unknown> };
+    configMod.config.codeScoreThreshold = 0.3;
+
+    const { codeModelSelector } = await import('../../../dist/modules/decision-engine/services/codeModelSelector.js') as {
+      codeModelSelector: {
+        findBestModelForSubtask: (subtask: unknown, task?: string) => Promise<{ id: string } | null>;
+        setModelPerformanceTracker: (t: unknown) => void;
+        _clearOpenRouterCache?: () => void;
+      };
+    };
+
+    codeModelSelector.setModelPerformanceTracker({
+      analyzePerformanceByComplexity: () => ({ averageSuccessRate: 0, averageQualityScore: 0, averageResponseTime: 0, averageTokenEfficiency: 0, averageResourceUsage: 0, bestPerformingModels: [] }),
+      getModelStats: () => ({ complexityScore: 0.3, successRate: 1.0, qualityScore: 1.0, avgResponseTime: 1000, tokenEfficiency: 1.0, systemResourceUsage: 0.1, memoryFootprint: 4 }),
+    });
+
+    const result = await codeModelSelector.findBestModelForSubtask(makeSubtask(500));
+
+    expect(result?.id).not.toBe('poor-coder');
+    expect(result?.id).toBe('good-coder');
+  });
+
+  it('does NOT exclude model with undefined code score (no benchmark data)', async () => {
+    const unBenchmarked = makeModel('new-coder');
+
+    costMonitorMock.getAvailableModels.mockResolvedValue([unBenchmarked]);
+
+    const detector = {
+      detectCapabilities: (_id: string) => fakeCapabilities(), // no scores
+    };
+    capDetectorModule._setCapabilityDetectorForTests(detector);
+
+    const configMod = await import('../../../dist/config/index.js') as { config: Record<string, unknown> };
+    configMod.config.codeScoreThreshold = 0.3;
+
+    const { codeModelSelector } = await import('../../../dist/modules/decision-engine/services/codeModelSelector.js') as {
+      codeModelSelector: {
+        findBestModelForSubtask: (subtask: unknown, task?: string) => Promise<{ id: string } | null>;
+        setModelPerformanceTracker: (t: unknown) => void;
+      };
+    };
+
+    codeModelSelector.setModelPerformanceTracker({
+      analyzePerformanceByComplexity: () => ({ averageSuccessRate: 0, averageQualityScore: 0, averageResponseTime: 0, averageTokenEfficiency: 0, averageResourceUsage: 0, bestPerformingModels: [] }),
+      getModelStats: () => ({ complexityScore: 0.3, successRate: 1.0, qualityScore: 1.0, avgResponseTime: 1000, tokenEfficiency: 1.0, systemResourceUsage: 0.1, memoryFootprint: 4 }),
+    });
+
+    const result = await codeModelSelector.findBestModelForSubtask(makeSubtask(500));
+
+    // Must be selected — no benchmark data ≠ poor performer
+    expect(result?.id).toBe('new-coder');
+  });
+
+  it('includes model with score 0.25 when CODE_SCORE_THRESHOLD overridden to 0.2', async () => {
+    const marginalCoder = makeModel('marginal-coder');
+
+    costMonitorMock.getAvailableModels.mockResolvedValue([marginalCoder]);
+
+    const detector = {
+      detectCapabilities: (_id: string) => fakeCapabilities({ scores: { code: 0.25 } }),
+    };
+    capDetectorModule._setCapabilityDetectorForTests(detector);
+
+    const configMod = await import('../../../dist/config/index.js') as { config: Record<string, unknown> };
+    configMod.config.codeScoreThreshold = 0.2; // lower threshold
+
+    const { codeModelSelector } = await import('../../../dist/modules/decision-engine/services/codeModelSelector.js') as {
+      codeModelSelector: {
+        findBestModelForSubtask: (subtask: unknown, task?: string) => Promise<{ id: string } | null>;
+        setModelPerformanceTracker: (t: unknown) => void;
+      };
+    };
+
+    codeModelSelector.setModelPerformanceTracker({
+      analyzePerformanceByComplexity: () => ({ averageSuccessRate: 0, averageQualityScore: 0, averageResponseTime: 0, averageTokenEfficiency: 0, averageResourceUsage: 0, bestPerformingModels: [] }),
+      getModelStats: () => ({ complexityScore: 0.3, successRate: 1.0, qualityScore: 1.0, avgResponseTime: 1000, tokenEfficiency: 1.0, systemResourceUsage: 0.1, memoryFootprint: 4 }),
+    });
+
+    const result = await codeModelSelector.findBestModelForSubtask(makeSubtask(500));
+
+    expect(result?.id).toBe('marginal-coder');
+
+    // Restore default
+    configMod.config.codeScoreThreshold = 0.3;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// codeModelSelector — largeContext filter for large prompts
+// ---------------------------------------------------------------------------
+
+describe('codeModelSelector largeContext filter (issue #28)', () => {
+  let capDetectorModule: { _setCapabilityDetectorForTests: (d: unknown) => void };
+  let costMonitorMock: { getAvailableModels: ReturnType<typeof jest.fn> };
+
+  beforeEach(async () => {
+    capDetectorModule = await import('../../../dist/modules/core/capability-detector.js') as typeof capDetectorModule;
+    const costMod = await import('../../../dist/modules/cost-monitor/index.js') as { costMonitor: { getAvailableModels: ReturnType<typeof jest.fn> } };
+    costMonitorMock = costMod.costMonitor;
+  });
+
+  afterEach(() => {
+    capDetectorModule._setCapabilityDetectorForTests(undefined);
+    jest.clearAllMocks();
+  });
+
+  it('excludes largeContext=false models for subtasks ≥ 32768 tokens', async () => {
+    const smallCtx = makeModel('small-ctx', 8192);
+    const largeCtx = makeModel('large-ctx', 131072);
+
+    costMonitorMock.getAvailableModels.mockResolvedValue([smallCtx, largeCtx]);
+
+    const detector = {
+      detectCapabilities: (id: string) => {
+        if (id === 'small-ctx') return fakeCapabilities({ largeContext: false, maxContextTokens: 8192 });
+        if (id === 'large-ctx') return fakeCapabilities({ largeContext: true, maxContextTokens: 131072 });
+        return fakeCapabilities();
+      },
+    };
+    capDetectorModule._setCapabilityDetectorForTests(detector);
+
+    const { codeModelSelector } = await import('../../../dist/modules/decision-engine/services/codeModelSelector.js') as {
+      codeModelSelector: {
+        findBestModelForSubtask: (subtask: unknown, task?: string) => Promise<{ id: string } | null>;
+        setModelPerformanceTracker: (t: unknown) => void;
+      };
+    };
+
+    codeModelSelector.setModelPerformanceTracker({
+      analyzePerformanceByComplexity: () => ({ averageSuccessRate: 0, averageQualityScore: 0, averageResponseTime: 0, averageTokenEfficiency: 0, averageResourceUsage: 0, bestPerformingModels: [] }),
+      getModelStats: () => ({ complexityScore: 0.3, successRate: 1.0, qualityScore: 1.0, avgResponseTime: 1000, tokenEfficiency: 1.0, systemResourceUsage: 0.1, memoryFootprint: 4 }),
+    });
+
+    const result = await codeModelSelector.findBestModelForSubtask(makeSubtask(40000));
+
+    expect(result?.id).toBe('large-ctx');
+  });
+
+  it('falls back to raw contextWindow when capability detector unavailable', async () => {
+    const smallRaw = makeModel('small-raw', 8192);
+    const largeRaw = makeModel('large-raw', 131072);
+
+    costMonitorMock.getAvailableModels.mockResolvedValue([smallRaw, largeRaw]);
+
+    // Detector throws — simulates uninitialised or unavailable state
+    const throwingDetector = {
+      detectCapabilities: () => { throw new Error('not initialised'); },
+    };
+    capDetectorModule._setCapabilityDetectorForTests(throwingDetector);
+
+    const { codeModelSelector } = await import('../../../dist/modules/decision-engine/services/codeModelSelector.js') as {
+      codeModelSelector: {
+        findBestModelForSubtask: (subtask: unknown, task?: string) => Promise<{ id: string } | null>;
+        setModelPerformanceTracker: (t: unknown) => void;
+      };
+    };
+
+    codeModelSelector.setModelPerformanceTracker({
+      analyzePerformanceByComplexity: () => ({ averageSuccessRate: 0, averageQualityScore: 0, averageResponseTime: 0, averageTokenEfficiency: 0, averageResourceUsage: 0, bestPerformingModels: [] }),
+      getModelStats: () => ({ complexityScore: 0.3, successRate: 1.0, qualityScore: 1.0, avgResponseTime: 1000, tokenEfficiency: 1.0, systemResourceUsage: 0.1, memoryFootprint: 4 }),
+    });
+
+    const result = await codeModelSelector.findBestModelForSubtask(makeSubtask(40000));
+
+    // Falls back to raw contextWindow: large-raw (131072 >= 40000) survives, small-raw excluded
+    expect(result?.id).toBe('large-raw');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `codeScoreThreshold` config field (default 0.3, overridable via `CODE_SCORE_THRESHOLD` env var) to filter models with poor empirical code benchmark scores from code routing
- `codeModelSelector`: applies score-threshold hard filter before model scoring; models with no benchmark data pass through (not-yet-measured ≠ poor performer); uses `largeContext` capability flag for subtasks ≥ 32 768 tokens with fallback to raw `contextWindow`
- `taskRouter`: uses `CapabilityDetector.detectCapabilities()` in candidate-filter loop with fallback to model registry capabilities when detector is unavailable

## Test plan

- [x] `capability-score-filter.test.ts` — 5 new tests covering: score threshold exclusion, unbenchmarked model pass-through, threshold override via config, largeContext flag filtering, detector-unavailable fallback to raw contextWindow
- [x] Full suite: 272 tests passing, 0 failures

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)