### PR TITLE
feat: per-provider inference timeout with structured error (Issue #20)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ API_PREFIX=/api
 # Local LLM Endpoints: These settings configure the endpoints for local Large Language Models.
 LM_STUDIO_ENDPOINT=http://localhost:1234/v1
 OLLAMA_ENDPOINT=http://localhost:11434/api
-OLLAMA_TIMEOUT=120000
+OLLAMA_TIMEOUT=120
 PROVIDER_MAX_CONCURRENT_LOCAL=2
 PROVIDER_MAX_CONCURRENT_REMOTE=5
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ PYTHON_DETECT_VENV=true
 - **Local LLM Endpoints**
   - `LM_STUDIO_ENDPOINT`: URL where your LM Studio instance is running
   - `OLLAMA_ENDPOINT`: URL where your Ollama instance is running
-  - `OLLAMA_TIMEOUT`: Per-request Ollama timeout in milliseconds (default `120000`)
+  - `OLLAMA_TIMEOUT`: Per-request Ollama timeout in seconds (default `120`)
   - `PROVIDER_TIMEOUT_MS`: Generic per-request timeout in milliseconds for providers without a specific override (default `120000`)
 
 - **Configuration**

--- a/docs/OPERATIONAL_TEST_PLAN.md
+++ b/docs/OPERATIONAL_TEST_PLAN.md
@@ -311,6 +311,8 @@ No test verifies what happens at the MCP tool-call timeout boundary. Currently, 
 
 2026-05-20 update: Issue 18's transport strategy decision is documented in `docs/PLAN.md` and ADR-0001: async jobs and queue-backed progress are the primary path; streaming chunks remain optional future work. Timeout-boundary live coverage is still pending because it needs a deterministic slow-model fixture.
 
+2026-05-19 update (Issue #20): Per-provider inference timeout is now implemented. `OLLAMA_TIMEOUT` (seconds, default `120`) applies to Ollama provider requests. `PROVIDER_TIMEOUT_MS` (milliseconds, default `120000`) is the generic fallback for LM Studio and OpenRouter. On expiry all three providers throw `InferenceTimeoutError`; the MCP surface in `src/index.ts` converts this to a structured JSON tool response `{error:"inference_timeout", providerId, timeoutMs}` with `isError:true`. Unit coverage: `test/modules/ollama/timeout.test.ts` verifies timeout-expiry error shape and success-within-window. Live end-to-end timeout boundary tests remain blocked pending a deterministic slow-model fixture (see Gap 1 blocker above).
+
 ---
 
 ### Gap 2 — Provider health failure injection (Issue 24 / Issue 26)

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -126,7 +126,7 @@ export const config: Config = {
   // Local LLM endpoints
   lmStudioEndpoint: process.env.LM_STUDIO_ENDPOINT || 'http://localhost:1234/v1',
   ollamaEndpoint: process.env.OLLAMA_ENDPOINT || 'http://localhost:11434/api',
-  ollamaTimeout: parseInt(process.env.OLLAMA_TIMEOUT || '120000', 10),
+  ollamaTimeout: parseInt(process.env.OLLAMA_TIMEOUT || '120', 10) * 1000,
   providerTimeoutMs: parseInt(process.env.PROVIDER_TIMEOUT_MS || '120000', 10),
   providerMaxConcurrentLocal: parseNumber(process.env.PROVIDER_MAX_CONCURRENT_LOCAL, 1, 1, 64),
   providerMaxConcurrentRemote: parseNumber(process.env.PROVIDER_MAX_CONCURRENT_REMOTE, 1, 1, 128),


### PR DESCRIPTION
## Summary

- `OLLAMA_TIMEOUT` env var now accepts **seconds** (default `120`) — config multiplies by 1000 internally so all existing ms-based paths are unchanged
- `PROVIDER_TIMEOUT_MS` remains in milliseconds (name is explicit), already used as fallback by LM Studio and OpenRouter
- All three providers already throw `InferenceTimeoutError`; MCP surface already converts to `{error:"inference_timeout", providerId, timeoutMs}` structured JSON
- Updated `.env.example` and `README.md` docs
- Added Issue #20 implementation note to `docs/OPERATIONAL_TEST_PLAN.md` Gap 1 entry

## Acceptance criteria status

- [x] `OLLAMA_TIMEOUT` env var (default 120 s) applied to Ollama provider requests
- [x] `PROVIDER_TIMEOUT_MS` accepted as generic fallback for providers without specific override
- [x] Timeout expiry returns structured `{error:"inference_timeout", timeoutMs}` — not a thrown exception at MCP surface
- [x] `npm run build` exits 0
- [x] `npm test` passes (276 tests, 41 suites) — existing `test/modules/ollama/timeout.test.ts` covers expiry shape + success-within-window
- [x] `docs/OPERATIONAL_TEST_PLAN.md` updated with timeout behavior note

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 276/276 pass
- [ ] Live: set `OLLAMA_TIMEOUT=5` and trigger a slow model call; verify `inference_timeout` JSON response with `timeoutMs: 5000`

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)