### PR TITLE
fix: wire CapabilityDetector into preemptiveRouting for code tasks (#49)

### DIFF
--- a/src/modules/decision-engine/index.ts
+++ b/src/modules/decision-engine/index.ts
@@ -16,7 +16,14 @@ import { modelPerformanceTracker } from './services/modelPerformance.js';
 import { lmStudioModule } from '../lm-studio/index.js';
 import { ollamaModule } from '../ollama/index.js';
 import { getProviderRegistry, isProviderLocal } from '../core/provider/index.js';
+import { getCapabilityDetector } from '../core/capability-detector.js';
 // import { taskRouter } from './services/taskRouter.js'; //TODO: Check and make sure this module is still used elsewhere in the codebase.
+
+const CODE_TASK_PATTERN = /\b(code|function|class|implement|debug|test|refactor|fix|bug|method|module|api|script|parse|algorithm|compile)\b/i;
+
+function isCodeTask(task: string): boolean {
+  return CODE_TASK_PATTERN.test(task);
+}
 /**
  * Represents a single factor in the routing decision.
  */
@@ -343,8 +350,12 @@ export const decisionEngine = {
       provider = localScore > paidScore ? 'local' : 'paid';
       confidence = Math.min(Math.abs(localScore - paidScore), 1.0);
       model = await this.selectModelForProvider(provider, complexity, totalTokens);
+
+      if (provider === 'local') {
+        model = await this.applyCodeCapabilityFilter(model, params.task, complexity, totalTokens);
+      }
     }
-    
+
     return {
       provider,
       model,
@@ -357,6 +368,33 @@ export const decisionEngine = {
       },
       preemptive: true
     };
+  },
+
+  async applyCodeCapabilityFilter(
+    selectedModel: string,
+    task: string,
+    complexity: number,
+    totalTokens: number,
+  ): Promise<string> {
+    if (!isCodeTask(task)) return selectedModel;
+    try {
+      const caps = getCapabilityDetector().detectCapabilities(selectedModel);
+      const threshold = config.codeScoreThreshold;
+      if (caps.scores?.code !== undefined && caps.scores.code < threshold) {
+        logger.debug(
+          `Preemptive routing: ${selectedModel} code score ${caps.scores.code} < threshold ${threshold}, seeking alternative`,
+        );
+        const alt = await modelSelector.getBestLocalModel(complexity, totalTokens, selectedModel);
+        if (alt && alt.id !== selectedModel) {
+          logger.debug(`Preemptive routing: capability filter replaced ${selectedModel} with ${alt.id}`);
+          return alt.id;
+        }
+        logger.debug(`Preemptive routing: no capable alternative found, keeping ${selectedModel}`);
+      }
+    } catch {
+      // CapabilityDetector not initialized — skip filter silently
+    }
+    return selectedModel;
   },
 
   /**

--- a/src/modules/decision-engine/services/modelSelector.ts
+++ b/src/modules/decision-engine/services/modelSelector.ts
@@ -43,17 +43,19 @@ export const modelSelector = {
    */
   async getBestLocalModel(
     complexity: number,
-    totalTokens: number
+    totalTokens: number,
+    excludeId?: string,
   ): Promise<Model | null> {
     try {
       // Get the models database
       const modelsDb = modelsDbService.getDatabase();
-      
+
       // Get local models
       const localModels = await costMonitor.getAvailableModels();
       const filteredLocalModels = localModels.filter(model =>
         isProviderLocal(model.provider) &&
-        (model.contextWindow === undefined || model.contextWindow >= totalTokens)
+        (model.contextWindow === undefined || model.contextWindow >= totalTokens) &&
+        model.id !== excludeId
       );
       
       if (filteredLocalModels.length === 0) {

--- a/test/modules/decision-engine/preemptive-routing.test.ts
+++ b/test/modules/decision-engine/preemptive-routing.test.ts
@@ -21,6 +21,20 @@ const mockGetBestLocalModel = jest
   .fn<() => Promise<{ id: string } | null>>()
   .mockResolvedValue({ id: 'llama-3.2-3b' });
 
+// CapabilityDetector mock — controls detectCapabilities per model id.
+const mockDetectCapabilities = jest.fn<(id: string) => { code?: boolean; scores?: { code?: number } }>(
+  () => ({ chat: true, code: true }),
+);
+const mockGetCapabilityDetector = jest.fn(() => ({
+  detectCapabilities: mockDetectCapabilities,
+}));
+
+jest.unstable_mockModule('../../../dist/modules/core/capability-detector.js', () => ({
+  getCapabilityDetector: mockGetCapabilityDetector,
+  _setCapabilityDetectorForTests: jest.fn(),
+  initCapabilityDetector: jest.fn(),
+}));
+
 jest.unstable_mockModule(
   '../../../dist/modules/decision-engine/services/modelSelector.js',
   () => ({
@@ -127,9 +141,17 @@ const { COMPLEXITY_THRESHOLDS, TOKEN_THRESHOLDS } = await import(
 
 describe('decisionEngine.preemptiveRouting', () => {
   beforeEach(() => {
+    mockHasFreeModels.mockReset();
+    mockGetBestFreeModel.mockReset();
+    mockGetBestLocalModel.mockReset();
+    mockDetectCapabilities.mockReset();
+    mockGetCapabilityDetector.mockReset();
+
     mockHasFreeModels.mockResolvedValue(false);
     mockGetBestFreeModel.mockResolvedValue(null);
     mockGetBestLocalModel.mockResolvedValue({ id: 'llama-3.2-3b' });
+    mockDetectCapabilities.mockReturnValue({ chat: true, code: true });
+    mockGetCapabilityDetector.mockReturnValue({ detectCapabilities: mockDetectCapabilities });
   });
 
   // ── Local preference ──────────────────────────────────────────────────────
@@ -244,5 +266,55 @@ describe('decisionEngine.preemptiveRouting', () => {
     expect(result.preemptive).toBe(true);
     expect(result.scores).toHaveProperty('local');
     expect(result.scores).toHaveProperty('paid');
+  });
+
+  // ── Issue #49: CapabilityDetector filter for code tasks ───────────────────
+
+  it('skips local model with code score below threshold when a better local model exists', async () => {
+    // First getBestLocalModel call returns the bad coder; second (with exclusion) returns good coder.
+    mockGetBestLocalModel
+      .mockResolvedValueOnce({ id: 'bad-coder-7b' })
+      .mockResolvedValueOnce({ id: 'good-coder-7b' });
+
+    mockDetectCapabilities.mockImplementation((id: string) => {
+      if (id === 'bad-coder-7b') return { chat: true, code: false, scores: { code: 0.1 } };
+      return { chat: true, code: true, scores: { code: 0.9 } };
+    });
+
+    const result = await decisionEngine.preemptiveRouting({
+      task: 'implement a function to parse JSON',
+      contextLength: 200,
+      expectedOutputLength: 100,
+      complexity: COMPLEXITY_THRESHOLDS.SIMPLE - 0.1,
+      priority: 'cost',
+    });
+
+    expect(result.provider).toBe('local');
+    expect(result.model).not.toBe('bad-coder-7b');
+    expect(result.model).toBe('good-coder-7b');
+  });
+
+  it('falls back to the original local model when no capable alternative exists', async () => {
+    // First call returns the bad coder; second call (exclusion fallback) returns null.
+    mockGetBestLocalModel
+      .mockResolvedValueOnce({ id: 'bad-coder-7b' })
+      .mockResolvedValueOnce(null);
+
+    mockDetectCapabilities.mockImplementation((id: string) => {
+      if (id === 'bad-coder-7b') return { chat: true, code: false, scores: { code: 0.1 } };
+      return { chat: true, code: true };
+    });
+
+    const result = await decisionEngine.preemptiveRouting({
+      task: 'implement a function to parse JSON',
+      contextLength: 200,
+      expectedOutputLength: 100,
+      complexity: COMPLEXITY_THRESHOLDS.SIMPLE - 0.1,
+      priority: 'cost',
+    });
+
+    // Must not crash — falls back gracefully to the only available model.
+    expect(result.provider).toBe('local');
+    expect(result.model).toBe('bad-coder-7b');
   });
 });


### PR DESCRIPTION
## Summary

- `preemptive_route_task` was ignoring benchmark-derived capability scores — a model marked as a poor code performer (scores.code < 0.3) would still be selected because `preemptiveRouting()` only consulted `modelsDbService`, not `CapabilityDetector`
- Violates ARCHITECTURAL_TRUTHS: *"If benchmark results cannot affect routing decisions, the benchmark system is considered non-functional"*
- Adds `applyCodeCapabilityFilter()` to `decisionEngine`: after selecting a local model for a code task, checks `CapabilityDetector.detectCapabilities()` and swaps to the next-best local model if code score < `codeScoreThreshold` (default 0.3)
- Adds `excludeId?` param to `modelSelector.getBestLocalModel()` to skip the already-rejected model when seeking an alternative
- Gracefully falls back to original model when no capable alternative exists; silently skips if `CapabilityDetector` is uninitialized

## Test plan

- [x] Two new regression tests in `preemptive-routing.test.ts`: swap-to-good-model and graceful-fallback-when-no-alternative
- [x] Fixed `beforeEach` mock isolation with `mockReset()` to prevent `mockResolvedValueOnce` leakage between tests
- [x] `npm run build` passes (zero tsc errors)
- [x] `npm test` passes — 281/281 tests, zero regressions
- [x] `node test-operational.mjs --suite routing` — 34/34 passed, 0 failed

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)