### PR TITLE
fix(issue-50): use ModelRegistry task-category scores in preemptive local model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ LocalLama MCP Server is designed to reduce token usage and costs without giving 
 - Defines rules that compare the cost of using the paid API against the cost (and potential quality trade-offs) of offloading to a local LLM
 - Includes configurable thresholds for when to offload
 - Uses preemptive routing based on benchmark data to make faster decisions without API calls
+- For preemptive local selection, task-category benchmark scores from ModelRegistry (for example `code`) are preferred over generic historical quality when available
 - New adaptive model selection system with performance history tracking
 - Enhanced code task decomposition with complexity analysis
 - **NEW** Smart task dependency mapping with critical path analysis

--- a/src/modules/decision-engine/index.ts
+++ b/src/modules/decision-engine/index.ts
@@ -336,6 +336,7 @@ export const decisionEngine = {
     let provider: 'local' | 'paid';
     let confidence: number;
     let model: string;
+    const taskCategory = isCodeTask(params.task) ? 'code' : undefined;
     
     // If free models are available and have the highest score, use them
     if (hasFreeModels && freeScore > localScore && freeScore > paidScore) {
@@ -349,10 +350,10 @@ export const decisionEngine = {
     } else {
       provider = localScore > paidScore ? 'local' : 'paid';
       confidence = Math.min(Math.abs(localScore - paidScore), 1.0);
-      model = await this.selectModelForProvider(provider, complexity, totalTokens);
+      model = await this.selectModelForProvider(provider, complexity, totalTokens, taskCategory);
 
       if (provider === 'local') {
-        model = await this.applyCodeCapabilityFilter(model, params.task, complexity, totalTokens);
+        model = await this.applyCodeCapabilityFilter(model, params.task, complexity, totalTokens, taskCategory);
       }
     }
 
@@ -375,6 +376,7 @@ export const decisionEngine = {
     task: string,
     complexity: number,
     totalTokens: number,
+    taskCategory?: string,
   ): Promise<string> {
     if (!isCodeTask(task)) return selectedModel;
     try {
@@ -384,7 +386,7 @@ export const decisionEngine = {
         logger.debug(
           `Preemptive routing: ${selectedModel} code score ${caps.scores.code} < threshold ${threshold}, seeking alternative`,
         );
-        const alt = await modelSelector.getBestLocalModel(complexity, totalTokens, selectedModel);
+        const alt = await modelSelector.getBestLocalModel(complexity, totalTokens, selectedModel, taskCategory);
         if (alt && alt.id !== selectedModel) {
           logger.debug(`Preemptive routing: capability filter replaced ${selectedModel} with ${alt.id}`);
           return alt.id;
@@ -584,10 +586,11 @@ export const decisionEngine = {
   async selectModelForProvider(
     provider: 'local' | 'paid',
     complexity: number,
-    totalTokens: number
+    totalTokens: number,
+    taskCategory?: string,
   ): Promise<string> {
     if (isProviderLocal(provider)) {
-      const bestModel = await modelSelector.getBestLocalModel(complexity, totalTokens);
+      const bestModel = await modelSelector.getBestLocalModel(complexity, totalTokens, undefined, taskCategory);
       return bestModel?.id || config.defaultLocalModel;
     } else {
       const preferredModelIds = complexity >= COMPLEXITY_THRESHOLDS.COMPLEX

--- a/src/modules/decision-engine/services/modelSelector.ts
+++ b/src/modules/decision-engine/services/modelSelector.ts
@@ -7,6 +7,25 @@ import { COMPLEXITY_THRESHOLDS } from '../types/index.js';
 // import { modelProfiles } from '../utils/modelProfiles.js';
 import { isOpenRouterConfigured } from '../../api-integration/tool-definition/index.js';
 import { isProviderId, isProviderLocal } from '../../core/provider/index.js';
+import { getModelRegistry } from '../../core/model/index.js';
+
+function getTaskCategoryScore(modelId: string, taskCategory?: string): number | undefined {
+  if (!taskCategory) return undefined;
+
+  const scores = getModelRegistry().getModel(modelId)?.benchmarkSummary?.scores;
+  if (!scores) return undefined;
+
+  switch (taskCategory) {
+    case 'code':
+      return scores.code;
+    case 'reasoning':
+      return scores.reasoning;
+    case 'speed':
+      return scores.speed;
+    default:
+      return undefined;
+  }
+}
 
 /**
  * Model Selector Service
@@ -45,6 +64,7 @@ export const modelSelector = {
     complexity: number,
     totalTokens: number,
     excludeId?: string,
+    taskCategory?: string,
   ): Promise<Model | null> {
     try {
       // Get the models database
@@ -89,9 +109,12 @@ export const modelSelector = {
           
           // Success rate factor (0-1)
           score += modelData.successRate * successRateWeight;
-          
-          // Quality score factor (0-1)
-          score += modelData.qualityScore * qualityScoreWeight;
+
+          // Prefer task-category benchmark score when available; otherwise use
+          // the generic quality score from modelsDb.
+          const taskCategoryScore = getTaskCategoryScore(model.id, taskCategory);
+          const qualitySignal = taskCategoryScore ?? modelData.qualityScore;
+          score += qualitySignal * qualityScoreWeight;
           
           // Response time factor (0-1, inversely proportional)
           // Normalize response time: faster is better
@@ -104,7 +127,7 @@ export const modelSelector = {
           const complexityMatchFactor = 1 - Math.abs(modelData.complexityScore - complexity);
           score += complexityMatchFactor * complexityMatchWeight;
           
-          logger.debug(`Local model ${model.id} has performance data: success=${modelData.successRate.toFixed(2)}, quality=${modelData.qualityScore.toFixed(2)}, time=${modelData.avgResponseTime}ms, score=${score.toFixed(2)}`);
+          logger.debug(`Local model ${model.id} has performance data: success=${modelData.successRate.toFixed(2)}, quality=${qualitySignal.toFixed(2)}${taskCategoryScore !== undefined ? ` (task:${taskCategory})` : ''}, time=${modelData.avgResponseTime}ms, score=${score.toFixed(2)}`);
           
           // For local models, we also consider system resource usage
           // This is a local-specific optimization

--- a/test/modules/decision-engine/modelSelector.task-category.test.ts
+++ b/test/modules/decision-engine/modelSelector.task-category.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.unstable_mockModule('../../../dist/utils/logger.js', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const mockGetAvailableModels = jest.fn<() => Promise<Array<{ id: string; provider: string; contextWindow: number }>>>()
+  .mockResolvedValue([]);
+
+jest.unstable_mockModule('../../../dist/modules/cost-monitor/index.js', () => ({
+  costMonitor: {
+    getAvailableModels: mockGetAvailableModels,
+    getFreeModels: jest.fn().mockResolvedValue([]),
+  },
+}));
+
+const mockGetDatabase = jest.fn(() => ({ models: {} }));
+jest.unstable_mockModule('../../../dist/modules/decision-engine/services/modelsDb.js', () => ({
+  modelsDbService: {
+    getDatabase: mockGetDatabase,
+  },
+}));
+
+const mockGetModel = jest.fn<(modelId: string) => { benchmarkSummary?: { scores?: { code?: number } } } | undefined>(() => undefined);
+jest.unstable_mockModule('../../../dist/modules/core/model/index.js', () => ({
+  getModelRegistry: () => ({
+    getModel: mockGetModel,
+  }),
+}));
+
+jest.unstable_mockModule('../../../dist/modules/openrouter/index.js', () => ({
+  openRouterModule: {
+    modelTracking: { models: {} },
+    initialize: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.unstable_mockModule('../../../dist/modules/api-integration/tool-definition/index.js', () => ({
+  isOpenRouterConfigured: () => false,
+}));
+
+jest.unstable_mockModule('../../../dist/modules/core/provider/index.js', () => ({
+  isProviderId: jest.fn().mockReturnValue(false),
+  isProviderLocal: jest.fn().mockImplementation((provider: string) => provider === 'ollama' || provider === 'lm-studio' || provider === 'local'),
+}));
+
+const { modelSelector } = await import('../../../dist/modules/decision-engine/services/modelSelector.js');
+
+describe('modelSelector.getBestLocalModel task-category scoring (issue #50)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('prefers stronger ModelRegistry task-category score over higher generic modelsDb quality', async () => {
+    mockGetAvailableModels.mockResolvedValue([
+      { id: 'model-a', provider: 'ollama', contextWindow: 8192 },
+      { id: 'model-b', provider: 'ollama', contextWindow: 8192 },
+    ]);
+
+    mockGetDatabase.mockReturnValue({
+      models: {
+        'model-a': {
+          benchmarkCount: 3,
+          successRate: 0.95,
+          qualityScore: 0.95,
+          avgResponseTime: 1000,
+          complexityScore: 0.5,
+        },
+        'model-b': {
+          benchmarkCount: 3,
+          successRate: 0.9,
+          qualityScore: 0.6,
+          avgResponseTime: 1000,
+          complexityScore: 0.5,
+        },
+      },
+    });
+
+    mockGetModel.mockImplementation((id: string) => {
+      if (id === 'model-a') return { benchmarkSummary: { scores: { code: 0.1 } } };
+      if (id === 'model-b') return { benchmarkSummary: { scores: { code: 0.9 } } };
+      return undefined;
+    });
+
+    const selected = await modelSelector.getBestLocalModel(0.5, 500, undefined, 'code');
+    expect(selected?.id).toBe('model-b');
+  });
+
+  it('preserves cold-start behavior when task-category score is unavailable', async () => {
+    mockGetAvailableModels.mockResolvedValue([
+      { id: 'model-a', provider: 'ollama', contextWindow: 8192 },
+      { id: 'model-b', provider: 'ollama', contextWindow: 8192 },
+    ]);
+
+    mockGetDatabase.mockReturnValue({
+      models: {
+        'model-a': {
+          benchmarkCount: 3,
+          successRate: 0.95,
+          qualityScore: 0.95,
+          avgResponseTime: 1000,
+          complexityScore: 0.5,
+        },
+        'model-b': {
+          benchmarkCount: 3,
+          successRate: 0.9,
+          qualityScore: 0.6,
+          avgResponseTime: 1000,
+          complexityScore: 0.5,
+        },
+      },
+    });
+
+    mockGetModel.mockReturnValue(undefined);
+
+    const selected = await modelSelector.getBestLocalModel(0.5, 500, undefined, 'code');
+    expect(selected?.id).toBe('model-a');
+  });
+});


### PR DESCRIPTION
## Summary
Implements Issue #50 telemetry-source behavior for preemptive local selection.

### What changed
- Added `taskCategory?: string` to `modelSelector.getBestLocalModel`.
- Threaded `taskCategory` through preemptive routing path:
  - `decisionEngine.selectModelForProvider(...)`
  - `decisionEngine.applyCodeCapabilityFilter(...)`
- In preemptive local scoring, when ModelRegistry has a task-category benchmark score, that score is used as the quality signal instead of generic `modelsDb` quality.
- Preserved cold-start behavior when ModelRegistry has no task-category score.
- Added focused unit test coverage for the new behavior.
- Updated README decision-engine bullet to document task-category score preference.

## Scope constraints respected
- No changes to `benchmarkService`.
- No changes to canonical `taskRouter` / `codeModelSelector` routing.
- Kept change local to preemptive local model selection.
- Did not broaden into Issues #51/#52/#53.

## Validation
- `npm run build`
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config=jest.config.mjs test/modules/decision-engine/modelSelector.task-category.test.ts test/modules/decision-engine/preemptive-routing.test.ts`
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config=jest.config.mjs test/modules/decision-engine`

## Behavior
- Before: higher generic `modelsDb` quality could beat a poor task-category benchmark score.
- After: for requested task category (e.g. `code`), stronger ModelRegistry task score is preferred when available; fallback remains generic/cold-start behavior when absent.