### PR TITLE
fix: load startup .env from rootDir instead of CWD

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ cp .env.example .env
 
 Then edit the `.env` file with your specific configuration:
 
+The server resolves `.env` from its own root directory (or `LOCALLAMA_ROOT_DIR` when set), not from the MCP host's current working directory.
+
 ```
 # Local LLM Endpoints
 LM_STUDIO_ENDPOINT=http://localhost:1234/v1

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,14 +2,14 @@ import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-// Load environment variables from .env file
-dotenv.config();
 // Resolve project root from the compiled file location so the server works
 // regardless of what cwd the MCP host process uses when spawning us.
 // dist/config/index.js → dist/config/ → dist/ → project root (3 levels up).
 // LOCALLAMA_ROOT_DIR overrides for tests or custom deployments.
 const rootDir = process.env.LOCALLAMA_ROOT_DIR ||
   path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+// Load environment variables from a stable root path instead of caller cwd.
+dotenv.config({ path: path.join(rootDir, '.env') });
 
 /**
  * Type definitions for the configuration

--- a/test/config/path-root.test.ts
+++ b/test/config/path-root.test.ts
@@ -11,6 +11,7 @@ const originalRootDir = process.env.LOCALLAMA_ROOT_DIR;
 const originalProviderMaxConcurrentLocal = process.env.PROVIDER_MAX_CONCURRENT_LOCAL;
 const originalProviderMaxConcurrentRemote = process.env.PROVIDER_MAX_CONCURRENT_REMOTE;
 const originalProviderTimeoutMs = process.env.PROVIDER_TIMEOUT_MS;
+const originalBenchmarkResultsPath = process.env.BENCHMARK_RESULTS_PATH;
 
 function importFreshModule(modulePath: string, cacheKey: string) {
   const moduleUrl = new URL(`${pathToFileURL(modulePath).href}?${cacheKey}`);
@@ -43,6 +44,12 @@ afterEach(() => {
   } else {
     process.env.PROVIDER_TIMEOUT_MS = originalProviderTimeoutMs;
   }
+
+  if (originalBenchmarkResultsPath === undefined) {
+    delete process.env.BENCHMARK_RESULTS_PATH;
+  } else {
+    process.env.BENCHMARK_RESULTS_PATH = originalBenchmarkResultsPath;
+  }
 });
 
 describe('root path resolution', () => {
@@ -55,11 +62,11 @@ describe('root path resolution', () => {
 
     const configModule = await importFreshModule(
       path.resolve(originalCwd, 'dist/config/index.js'),
-      `config=${Date.now()}`
+      `config=${randomUUID()}`
     );
     const lockModule = await importFreshModule(
       path.resolve(originalCwd, 'dist/utils/lock-file.js'),
-      `lock=${Date.now()}`
+      `lock=${randomUUID()}`
     );
 
     try {
@@ -74,6 +81,50 @@ describe('root path resolution', () => {
     } finally {
       lockModule.removeLockFile();
       process.chdir(originalCwd);
+      fs.rmSync(tempRootDir, { recursive: true, force: true });
+      fs.rmSync(foreignCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('loads startup .env from rootDir rather than caller cwd', async () => {
+    const tempRootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'locallama-root-env-'));
+    const foreignCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'locallama-cwd-env-'));
+    const expectedResultsPath = path.join(tempRootDir, 'from-root');
+    const distConfigHref = pathToFileURL(path.resolve(originalCwd, 'dist/config/index.js')).href;
+
+    fs.writeFileSync(path.join(tempRootDir, '.env'), `BENCHMARK_RESULTS_PATH=${expectedResultsPath}\n`, 'utf8');
+    fs.writeFileSync(path.join(foreignCwd, '.env'), 'BENCHMARK_RESULTS_PATH=from-cwd\n', 'utf8');
+
+    const childEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      LOCALLAMA_ROOT_DIR: tempRootDir,
+    };
+    delete childEnv.BENCHMARK_RESULTS_PATH;
+
+    try {
+      const script = [
+        `import('${distConfigHref}').then(({ config }) => {`,
+        'console.log(config.benchmark.resultsPath);',
+        '});',
+      ].join('');
+      const output = execFileSync(
+        process.execPath,
+        ['--input-type=module', '-e', script],
+        {
+          cwd: foreignCwd,
+          env: childEnv,
+          encoding: 'utf8',
+        },
+      );
+
+      const resolvedPath = output
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+        .pop();
+
+      expect(resolvedPath).toBe(expectedResultsPath);
+    } finally {
       fs.rmSync(tempRootDir, { recursive: true, force: true });
       fs.rmSync(foreignCwd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- anchor startup dotenv load to `rootDir/.env` instead of implicit CWD lookup
- add a regression test proving startup config resolves `.env` from server root even when launched from a foreign working directory
- document `.env` resolution behavior in README

## Validation
- npm run build
- node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config=jest.config.mjs test/config/path-root.test.ts

Closes #57