### PR TITLE
fix(issue-52): route downstream model calls via provider registry

### DIFF
--- a/src/modules/core/provider/helpers.ts
+++ b/src/modules/core/provider/helpers.ts
@@ -1,5 +1,6 @@
 import { CostClass } from './types.js';
 import { getProviderRegistry } from './registry.js';
+import type { TaskExecutionOptions, TaskExecutionResult } from './types.js';
 
 /**
  * Fallback set of provider ids known to be local. Consulted only when the
@@ -52,4 +53,37 @@ export function isProviderId(
   const provider = getProviderRegistry().get(modelProvider);
   if (provider) return provider.id === expectedId;
   return modelProvider === expectedId;
+}
+
+/**
+ * Execute a task through the provider registry so all callers inherit
+ * circuit-breaker and concurrency-limit protections.
+ */
+export async function executeProviderTask(
+  providerId: string,
+  modelId: string,
+  task: string,
+  options?: TaskExecutionOptions,
+): Promise<TaskExecutionResult> {
+  const registry = getProviderRegistry();
+  const provider = registry.get(providerId);
+  if (!provider) {
+    throw new Error(`Provider '${providerId}' is not registered`);
+  }
+
+  if (!registry.isAvailable(provider.id)) {
+    throw new Error(`Provider '${provider.id}' is temporarily unavailable (circuit open)`);
+  }
+
+  try {
+    const result = await registry.executeWithConcurrencyLimit(
+      provider,
+      async () => await provider.executeTask(modelId, task, options),
+    );
+    registry.recordProviderSuccess(provider.id);
+    return result;
+  } catch (error) {
+    registry.recordProviderFailure(provider.id);
+    throw error;
+  }
 }

--- a/src/modules/core/provider/index.ts
+++ b/src/modules/core/provider/index.ts
@@ -4,7 +4,12 @@ export {
   getProviderRegistry,
   _setProviderRegistryForTests,
 } from './registry.js';
-export { isProviderLocal, providerCostClass, isProviderId } from './helpers.js';
+export {
+  isProviderLocal,
+  providerCostClass,
+  isProviderId,
+  executeProviderTask,
+} from './helpers.js';
 export {
   localProviderLifecycle,
   _resetLocalProviderLifecycleForTests,

--- a/src/modules/decision-engine/services/benchmarkService.ts
+++ b/src/modules/decision-engine/services/benchmarkService.ts
@@ -11,7 +11,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { speculativeDecodingService } from '../services/speculativeDecoding.js';
 import { Model } from '../../../types/index.js';
-import { getProviderRegistry, isProviderId, isProviderLocal } from '../../core/provider/index.js';
+import { executeProviderTask, getProviderRegistry, isProviderId, isProviderLocal } from '../../core/provider/index.js';
 import { config } from '../../../config/index.js';
 
 // Add this interface at the top of the file with other types
@@ -477,30 +477,26 @@ export const benchmarkService = {
       const dynamicTimeout = 120000 * (contextWindow >= 16384 ? 3 : contextWindow >= 8192 ? 2 : 1.5) * 
                             (1 + complexity) * (modelId.includes('32b') || modelId.includes('70b') ? 1.5 : 1.0);
       
-      let result;
-      // Call the appropriate API
-      if (isProviderId(provider, 'lm-studio')) {
-        logger.info(`Calling LM Studio API for model ${modelId}`);
-        result = await callLmStudioApi(
+      let result: { success: boolean; text?: string; error?: string };
+      try {
+        const targetProviderId = isProviderId(provider, 'lm-studio')
+          ? 'lm-studio'
+          : isProviderId(provider, 'ollama')
+            ? 'ollama'
+            : 'openrouter';
+        logger.info(`Calling provider ${targetProviderId} for model ${modelId}`);
+        const executionResult = await executeProviderTask(
+          targetProviderId,
           modelId,
           task,
-          Math.round(dynamicTimeout) // Use dynamic timeout
+          { timeoutMs: Math.round(dynamicTimeout) },
         );
-      } else if (isProviderId(provider, 'ollama')) {
-        logger.info(`Calling Ollama API for model ${modelId}`);
-        result = await callOllamaApi(
-          modelId,
-          task,
-          Math.round(dynamicTimeout) // Use dynamic timeout
-        );
-      } else {
-        // Default to OpenRouter for other providers
-        logger.info(`Calling OpenRouter API for model ${modelId}`);
-        result = await openRouterModule.callOpenRouterApi(
-          modelId,
-          task,
-          Math.round(dynamicTimeout) // Use dynamic timeout
-        );
+        result = { success: true, text: executionResult.content };
+      } catch (error) {
+        result = {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
       }
       
       // Measure end time

--- a/src/modules/decision-engine/services/codeEvaluationService.ts
+++ b/src/modules/decision-engine/services/codeEvaluationService.ts
@@ -1,7 +1,7 @@
 import { logger } from '../../../utils/logger.js';
-import { openRouterModule } from '../../openrouter/index.js';
 import { costMonitor } from '../../cost-monitor/index.js';
 import { CodeEvaluationOptions, ModelCodeEvaluationResult } from '../types/index.js';
+import { executeProviderTask } from '../../core/provider/index.js';
 // import { Model } from '../../../types/index.js'; // Import Model type for proper typing
 
 interface ErrorResponse {
@@ -276,19 +276,18 @@ export const codeEvaluationService = {
     const detailedAnalysis = options?.detailedAnalysis ?? false;
     const evaluationPrompt = this.constructCodeEvaluationPrompt(task, response, taskType, detailedAnalysis);
 
-    const result = await openRouterModule.callOpenRouterApi(
-      modelId,
-      evaluationPrompt,
-      timeout
-    );
-
-    if (!result.success || !result.text) {
-      throw new Error(`Model evaluation failed: ${result.error}`);
+    let resultText: string;
+    try {
+      const result = await executeProviderTask('openrouter', modelId, evaluationPrompt, { timeoutMs: timeout });
+      resultText = result.content;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      throw new Error(`Model evaluation failed: ${errorMessage}`);
     }
 
     try {
-      const jsonMatch = result.text.match(/```json\n([\s\S]*?)\n```/) ||
-                        result.text.match(/\{[\\s\S]*"qualityScore"[\s\S]*\}/);
+      const jsonMatch = resultText.match(/```json\n([\s\S]*?)\n```/) ||
+            resultText.match(/\{[\\s\S]*"qualityScore"[\s\S]*\}/);
 
       if (jsonMatch) {
         const jsonStr = jsonMatch[1] || jsonMatch[0];

--- a/src/modules/decision-engine/services/codeTaskAnalyzer.ts
+++ b/src/modules/decision-engine/services/codeTaskAnalyzer.ts
@@ -1,5 +1,4 @@
 import { logger } from '../../../utils/logger.js';
-import { openRouterModule } from '../../openrouter/index.js';
 import { costMonitor } from '../../cost-monitor/index.js';
 import { 
   CodeTaskAnalysisOptions, 
@@ -14,6 +13,7 @@ import { config } from '../../../config/index.js';
 import { COMPLEXITY_THRESHOLDS } from '../types/index.js';
 import { Model } from '../../../types/index.js';
 import { lmStudioModule } from '../../lm-studio/index.js';
+import { executeProviderTask } from '../../core/provider/index.js';
 
 // Define a type for the raw subtask data parsed from the model response
 type RawSubtask = {
@@ -134,8 +134,8 @@ export const codeTaskAnalyzer = {
       const prompt = DECOMPOSE_TASK_PROMPT.replace('{task}', task);
       
       // Try using OpenRouter first
-      let response = null;
-      let errorDetails = null;
+      let response: string | null = null;
+      let errorDetails: { message: string } | null = null;
 
       try {
         // For more complex tasks, use a model to decompose the task
@@ -161,31 +161,19 @@ export const codeTaskAnalyzer = {
         }
         
         logger.debug(`Attempting decomposition API call with model: ${modelId}`);
-        const decompositionResult = await openRouterModule.callOpenRouterApi(
+        const decompositionResult = await executeProviderTask(
+          'openrouter',
           modelId,
           prompt,
-          60000 // 60 seconds timeout
+          { timeoutMs: 60000 },
         );
-        logger.debug(`Decomposition API call completed. Success: ${decompositionResult.success}, Text available: ${!!decompositionResult.text}`);
-        
-        if (!decompositionResult.success || !decompositionResult.text) {
-          // Capture detailed error information for later logging
-          const errorType = decompositionResult.error || 'unknown';
-          const errorInstance = decompositionResult.errorInstance;
-          const errorMessage = errorInstance ? errorInstance.message : 'Unknown error';
-          errorDetails = {
-            type: errorType,
-            message: errorMessage,
-            instance: errorInstance
-          };
-          
-          logger.warn(`OpenRouter API failed for task decomposition: ${errorType} - ${errorMessage}`);
-          throw new Error(`OpenRouter API failed: ${errorType}`);
-        }
-        
-        response = decompositionResult.text;
+        logger.debug(`Decomposition API call completed. Text available: ${!!decompositionResult.content}`);
+        response = decompositionResult.content;
         
       } catch (openRouterError) {
+        const errorMessage = openRouterError instanceof Error ? openRouterError.message : String(openRouterError);
+        errorDetails = { message: errorMessage };
+        logger.warn(`OpenRouter provider execution failed for task decomposition: ${errorMessage}`);
         // If OpenRouter failed, try LM-Studio as a fallback
         logger.info('OpenRouter decomposition failed, trying LM-Studio as fallback');
         
@@ -215,26 +203,23 @@ export const codeTaskAnalyzer = {
                 const selectedModel = preferredModels.length > 0 ? preferredModels[0] : lmModels[0];
                 logger.info(`Using LM-Studio model ${selectedModel.id} for task decomposition`);
                 
-                // Call LM-Studio API using the callLMStudioApi method on the module
-                const result = await lmStudioModule.callLMStudioApi(
+                const result = await executeProviderTask(
+                  'lm-studio',
                   selectedModel.id,
                   prompt,
-                  60000 // 60 seconds timeout
+                  { timeoutMs: 60000 },
                 );
-                
-                if (result.success && result.text) {
+
+                if (result.content) {
                   logger.info('Successfully used LM-Studio for task decomposition');
-                  response = result.text;
+                  response = result.content;
                 } else {
                   // Log specific LM-Studio error
-                  logger.error('LM-Studio fallback failed:', result.error || 'Unknown error');
+                  logger.error('LM-Studio fallback failed: empty response content');
                   
                   // If we have detailed error info from OpenRouter, log it for diagnostics
                   if (errorDetails) {
                     logger.error('Original OpenRouter error details:', errorDetails);
-                    if (errorDetails.instance && errorDetails.instance.stack) {
-                      logger.debug('OpenRouter error stack:', errorDetails.instance.stack);
-                    }
                   }
                   
                   // Both OpenRouter and LM-Studio failed, throw combined error
@@ -258,10 +243,7 @@ export const codeTaskAnalyzer = {
           
           // Log OpenRouter error details
           if (errorDetails) {
-            logger.error(`OpenRouter error: ${errorDetails.type} - ${errorDetails.message}`);
-            if (errorDetails.instance && errorDetails.instance.stack) {
-              logger.debug('OpenRouter error stack:', errorDetails.instance.stack);
-            }
+            logger.error(`OpenRouter error: ${errorDetails.message}`);
           } else {
             logger.error('OpenRouter error:', openRouterError);
           }
@@ -421,48 +403,15 @@ export const codeTaskAnalyzer = {
         try {
           logger.debug(`Attempt ${retryCount + 1}/${maxRetries + 1} to call model API for complexity analysis`);
           
-          const result = await openRouterModule.callOpenRouterApi(
+          const result = await executeProviderTask(
+            'openrouter',
             modelId,
             prompt,
-            30000 // 30 seconds timeout
+            { timeoutMs: 30000 },
           );
 
-          if (!result.success || !result.text) {
-            // Check for specific error types to determine if retry is appropriate
-            if (result.error && ['rate_limit', 'server_error'].includes(result.error)) {
-              // These errors are retryable
-              lastError = result.errorInstance || new Error(`API error: ${result.error}`);
-              retryCount++;
-              
-              if (retryCount <= maxRetries) {
-                // Try a different model if available on subsequent attempts
-                if (freeModels.length > retryCount) {
-                  modelId = freeModels[retryCount].id;
-                  logger.debug(`Retrying with different model ${modelId}`);
-                }
-                
-                // Wait before retrying (exponential backoff)
-                const backoffTime = Math.min(1000 * Math.pow(2, retryCount), 8000);
-                logger.debug(`Waiting ${backoffTime}ms before retry`);
-                await new Promise(resolve => setTimeout(resolve, backoffTime));
-                continue;
-              }
-            }
-            
-            // Non-retryable error or max retries exceeded
-            // Log detailed error before throwing
-            const errorType = result.error || 'Unknown error';
-            const errorInstance = result.errorInstance;
-            const errorMessage = errorInstance ? errorInstance.message : 'API returned unsuccessful result';
-            logger.warn(`Model API failed for complexity analysis using model ${modelId}: Type=${errorType}, Message=${errorMessage}`);
-            if (errorInstance && errorInstance.stack) {
-              logger.debug(`Complexity analysis error stack trace: ${errorInstance.stack}`);
-            }
-            throw new Error(`API error: ${errorType} - ${errorMessage}`);
-          }
-
           // Successful response, parse it
-          llmAnalysis = this.parseComplexityFromResponse(result.text);
+          llmAnalysis = this.parseComplexityFromResponse(result.content);
           break; // Exit the retry loop on success
           
         } catch (apiError) {

--- a/src/modules/fallback-handler/index.ts
+++ b/src/modules/fallback-handler/index.ts
@@ -1,7 +1,7 @@
 /* Required dependencies - used throughout the module */
 import { logger } from '../../utils/logger.js';
 import { config } from '../../config/index.js';
-import { getProviderRegistry } from '../core/provider/index.js';
+import { executeProviderTask, getProviderRegistry } from '../core/provider/index.js';
 import { openRouterModule } from '../openrouter/index.js';
 
 interface FallbackResult {
@@ -55,36 +55,34 @@ export const fallbackHandler = {
       if (task && timeout) {
         if (costClass === 'local' && fallbackOption === 'paid-api') {
           if (modelId) {
-            const openRouterResult = await openRouterModule.callOpenRouterApi(modelId, task, timeout);
+            const openRouterResult = await executeProviderTask('openrouter', modelId, task, { timeoutMs: timeout });
 
-            if (openRouterResult.success) {
+            if (openRouterResult.content) {
               fallbackResult = {
                 costClass: 'paid' as const,
                 success: true,
-                text: openRouterResult.text,
-                usage: openRouterResult.usage,
+                text: openRouterResult.content,
                 message: 'Fallback to OpenRouter API successful',
               };
             } else {
-              throw new Error(`OpenRouter API fallback failed: ${openRouterResult.error}`);
+              throw new Error('OpenRouter API fallback failed: empty response content');
             }
           } else {
             const freeModels = await openRouterModule.getFreeModels();
             if (freeModels.length > 0) {
               const bestModel = freeModels[0];
-              const openRouterResult = await openRouterModule.callOpenRouterApi(bestModel.id, task, timeout);
+              const openRouterResult = await executeProviderTask('openrouter', bestModel.id, task, { timeoutMs: timeout });
 
-              if (openRouterResult.success) {
+              if (openRouterResult.content) {
                 fallbackResult = {
                   costClass: 'paid' as const,
                   model: bestModel.id,
                   success: true,
-                  text: openRouterResult.text,
-                  usage: openRouterResult.usage,
+                  text: openRouterResult.content,
                   message: `Fallback to OpenRouter API (model: ${bestModel.id}) successful`,
                 };
               } else {
-                throw new Error(`OpenRouter API fallback failed: ${openRouterResult.error}`);
+                throw new Error('OpenRouter API fallback failed: empty response content');
               }
             } else {
               throw new Error('No free models available for fallback');
@@ -97,7 +95,7 @@ export const fallbackHandler = {
           }
           const models = await provider.listModels();
           const fallbackModelId = models.length > 0 ? models[0].id : config.defaultLocalModel;
-          const result = await provider.executeTask(fallbackModelId, task, { timeoutMs: timeout });
+          const result = await executeProviderTask(fallbackOption, fallbackModelId, task, { timeoutMs: timeout });
           fallbackResult = {
             costClass: 'local' as const,
             model: fallbackModelId,

--- a/test/modules/core/provider/helpers.test.ts
+++ b/test/modules/core/provider/helpers.test.ts
@@ -16,6 +16,7 @@ const {
   isProviderLocal,
   providerCostClass,
   isProviderId,
+  executeProviderTask,
 } = providerModule;
 
 function fakeProvider(id: string, costClass: 'local' | 'free' | 'paid', isLocal: boolean) {
@@ -100,6 +101,45 @@ describe('provider helpers', () => {
     it('handles null/undefined', () => {
       expect(isProviderId(undefined, 'lm-studio')).toBe(false);
       expect(isProviderId(null, 'lm-studio')).toBe(false);
+    });
+  });
+
+  describe('executeProviderTask', () => {
+    it('executes through provider and returns result content', async () => {
+      const registry = new ProviderRegistry();
+      const provider = fakeProvider('openrouter', 'paid', false);
+      registry.register(provider);
+      _setProviderRegistryForTests(registry);
+
+      const result = await executeProviderTask('openrouter', 'test-model', 'ping', { timeoutMs: 1234 });
+
+      expect(provider.executeTask).toHaveBeenCalledWith('test-model', 'ping', { timeoutMs: 1234 });
+      expect(result.content).toBe('');
+    });
+
+    it('fails fast when provider circuit is open', async () => {
+      const registry = new ProviderRegistry();
+      const provider = fakeProvider('openrouter', 'paid', false);
+      registry.register(provider);
+      jest.spyOn(registry, 'isAvailable').mockReturnValue(false);
+      _setProviderRegistryForTests(registry);
+
+      await expect(executeProviderTask('openrouter', 'test-model', 'ping')).rejects.toThrow(
+        /temporarily unavailable \(circuit open\)/,
+      );
+      expect(provider.executeTask).not.toHaveBeenCalled();
+    });
+
+    it('records provider failure when execution throws', async () => {
+      const registry = new ProviderRegistry();
+      const provider = fakeProvider('openrouter', 'paid', false);
+      provider.executeTask = jest.fn(() => Promise.reject(new Error('provider failed')));
+      registry.register(provider);
+      const recordFailureSpy = jest.spyOn(registry, 'recordProviderFailure');
+      _setProviderRegistryForTests(registry);
+
+      await expect(executeProviderTask('openrouter', 'test-model', 'ping')).rejects.toThrow('provider failed');
+      expect(recordFailureSpy).toHaveBeenCalledWith('openrouter');
     });
   });
 });

--- a/test/modules/decision-engine/codeEvaluationService.provider-routing.test.ts
+++ b/test/modules/decision-engine/codeEvaluationService.provider-routing.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+
+jest.unstable_mockModule('../../../dist/utils/logger.js', () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const mockExecuteProviderTask = jest.fn();
+jest.unstable_mockModule('../../../dist/modules/core/provider/index.js', () => ({
+  executeProviderTask: mockExecuteProviderTask,
+}));
+
+jest.unstable_mockModule('../../../dist/modules/cost-monitor/index.js', () => ({
+  costMonitor: {
+    getFreeModels: jest.fn(async () => [{ id: 'openrouter:free-model' }]),
+  },
+}));
+
+const { codeEvaluationService } = await import('../../../dist/modules/decision-engine/services/codeEvaluationService.js');
+
+describe('codeEvaluationService provider routing', () => {
+  beforeEach(() => {
+    mockExecuteProviderTask.mockReset();
+  });
+
+  it('routes model evaluation through executeProviderTask with openrouter provider', async () => {
+    mockExecuteProviderTask.mockResolvedValue({
+      content: '{"qualityScore":0.8,"explanation":"ok","isValid":true}',
+      model: 'free-model',
+    });
+
+    const result = await codeEvaluationService.evaluateCodeWithModel(
+      'Write a sum function',
+      'function sum(a,b){return a+b;}',
+      'general',
+      { timeoutMs: 1234 },
+    );
+
+    expect(mockExecuteProviderTask).toHaveBeenCalledWith(
+      'openrouter',
+      'openrouter:free-model',
+      expect.any(String),
+      { timeoutMs: 1234 },
+    );
+    expect(result.qualityScore).toBe(0.8);
+    expect(result.isValid).toBe(true);
+  });
+
+  it('surfaces circuit-open provider errors during model evaluation', async () => {
+    mockExecuteProviderTask.mockRejectedValue(
+      new Error("Provider 'openrouter' is temporarily unavailable (circuit open)"),
+    );
+
+    await expect(
+      codeEvaluationService.evaluateCodeWithModel(
+        'Write a sum function',
+        'function sum(a,b){return a+b;}',
+        'general',
+        { modelId: 'openrouter:free-model', timeoutMs: 500 },
+      ),
+    ).rejects.toThrow(/temporarily unavailable \(circuit open\)/);
+  });
+});


### PR DESCRIPTION
Closes #52.\n\n- Add executeProviderTask helper with circuit and concurrency controls\n- Replace direct OpenRouter API calls in code evaluation, task analyzer, benchmark, and fallback flows\n- Add regression tests for provider helper and code evaluation provider-routing\n- All tests and operational validation pass