### PR TITLE
fix: implement same-provider model unloading to prevent VRAM bloat (#53)

### DIFF
--- a/src/modules/core/provider/local-runtime-lifecycle.ts
+++ b/src/modules/core/provider/local-runtime-lifecycle.ts
@@ -12,6 +12,7 @@ export const localProviderLifecycle = {
     }
 
     if (activeLocalProviderId && activeLocalProviderId !== provider.id) {
+      // Cross-provider switch: unload the previous provider's model.
       const previousProvider = getProviderRegistry().get(activeLocalProviderId);
       if (previousProvider?.isLocal && previousProvider.releaseResources) {
         logger.info(
@@ -24,6 +25,26 @@ export const localProviderLifecycle = {
       } else {
         logger.debug(
           `Switching local execution from ${activeLocalProviderId} to ${provider.id} without explicit release hook on the previous provider`,
+        );
+      }
+    } else if (
+      activeLocalProviderId === provider.id &&
+      activeLocalModelId !== undefined &&
+      activeLocalModelId !== modelId
+    ) {
+      // Same-provider model switch: unload the previously loaded model to
+      // free VRAM before loading the new one.
+      if (provider.releaseResources) {
+        logger.info(
+          `Switching model within ${provider.id} from ${activeLocalModelId} to ${modelId}; unloading previous model to reclaim VRAM`,
+        );
+        await provider.releaseResources({
+          reason: 'same-provider-model-switch',
+          modelId: activeLocalModelId,
+        });
+      } else {
+        logger.debug(
+          `Model switch within ${provider.id} from ${activeLocalModelId} to ${modelId}: provider has no releaseResources hook`,
         );
       }
     }

--- a/src/modules/core/provider/types.ts
+++ b/src/modules/core/provider/types.ts
@@ -58,7 +58,7 @@ export interface LLMProvider {
   ): Promise<TaskExecutionResult>;
 
   releaseResources?(options?: {
-    reason?: 'cross-provider-handoff' | 'shutdown' | 'manual';
+    reason?: 'cross-provider-handoff' | 'same-provider-model-switch' | 'shutdown' | 'manual';
     modelId?: string;
   }): Promise<void>;
 

--- a/src/modules/lm-studio/provider.ts
+++ b/src/modules/lm-studio/provider.ts
@@ -88,7 +88,7 @@ class LMStudioProvider implements LLMProvider {
     return { content, model: id };
   }
 
-  async releaseResources(options?: { reason?: 'cross-provider-handoff' | 'shutdown' | 'manual'; modelId?: string }): Promise<void> {
+  async releaseResources(options?: { reason?: 'cross-provider-handoff' | 'same-provider-model-switch' | 'shutdown' | 'manual'; modelId?: string }): Promise<void> {
     const modelId = options?.modelId ?? this.lastExecutedModelId;
     if (!modelId) {
       return;

--- a/src/modules/ollama/provider.ts
+++ b/src/modules/ollama/provider.ts
@@ -78,7 +78,7 @@ class OllamaProvider implements LLMProvider {
     return { content, model: id };
   }
 
-  async releaseResources(options?: { reason?: 'cross-provider-handoff' | 'shutdown' | 'manual'; modelId?: string }): Promise<void> {
+  async releaseResources(options?: { reason?: 'cross-provider-handoff' | 'same-provider-model-switch' | 'shutdown' | 'manual'; modelId?: string }): Promise<void> {
     const modelId = options?.modelId ?? this.lastExecutedModelId;
     if (!modelId) {
       return;

--- a/test-operational.mjs
+++ b/test-operational.mjs
@@ -780,10 +780,19 @@ async function runSuite(client, serverEnv) {
       _setProviderRegistryForTests(registry);
 
       try {
+        // Each switch to a different model within the same provider should trigger
+        // a releaseResources call for the previously loaded model.
         await localProviderLifecycle.beforeExecution(ollama, 'model-a');
+        assert(unloadCalls.length === 0, '[mock][F-2b] no unload on first execution (no previous model)');
+
         await localProviderLifecycle.beforeExecution(ollama, 'model-b');
+        assert(unloadCalls.length === 1, '[mock][F-2b] one unload after first same-provider model switch');
+        assert(unloadCalls[0]?.reason === 'same-provider-model-switch', '[mock][F-2b] reason is same-provider-model-switch');
+        assert(unloadCalls[0]?.modelId === 'model-a', '[mock][F-2b] unloads the previously active model (model-a)');
+
         await localProviderLifecycle.beforeExecution(ollama, 'model-c');
-        assert(unloadCalls.length === 0, '[mock][F-2b] same-provider reuse across 3 model switches triggers zero releaseResources calls — no VRAM accumulation signal');
+        assert(unloadCalls.length === 2, '[mock][F-2b] two unloads after two same-provider model switches');
+        assert(unloadCalls[1]?.modelId === 'model-b', '[mock][F-2b] second unload targets model-b');
       } finally {
         _resetLocalProviderLifecycleForTests();
         _setProviderRegistryForTests(undefined);
@@ -833,6 +842,55 @@ async function runSuite(client, serverEnv) {
         assert(unloadLog[0].providerId === 'ollama' && unloadLog[0].modelId === 'model-A', '[mock][F-2c] first unload: ollama:model-A');
         assert(unloadLog[1].providerId === 'lm-studio' && unloadLog[1].modelId === 'model-B', '[mock][F-2c] second unload: lm-studio:model-B');
         assert(unloadLog[2].providerId === 'ollama' && unloadLog[2].modelId === 'model-C', '[mock][F-2c] third unload: ollama:model-C');
+      } finally {
+        _resetLocalProviderLifecycleForTests();
+        _setProviderRegistryForTests(undefined);
+      }
+    });
+
+    await runTest('[mock][F-2d] same-provider model switch triggers releaseResources for the previous model', async () => {
+      const {
+        ProviderRegistry,
+        _setProviderRegistryForTests,
+        localProviderLifecycle,
+        _resetLocalProviderLifecycleForTests,
+      } = await import('./dist/modules/core/provider/index.js');
+
+      _resetLocalProviderLifecycleForTests();
+
+      const unloadLog = [];
+      const ollama = {
+        id: 'ollama',
+        displayName: 'ollama',
+        costClass: 'local',
+        isLocal: true,
+        init: async () => {},
+        isAvailable: async () => true,
+        listModels: async () => [],
+        supportsModel: () => true,
+        executeTask: async () => ({ content: 'ok', model: 'ollama' }),
+        releaseResources: async (opts) => { unloadLog.push({ reason: opts?.reason, modelId: opts?.modelId }); },
+        getCost: () => ({ prompt: 0, completion: 0 }),
+      };
+
+      const registry = new ProviderRegistry();
+      registry.register(ollama);
+      _setProviderRegistryForTests(registry);
+
+      try {
+        // Load model-A: no previous model, so no unload
+        await localProviderLifecycle.beforeExecution(ollama, 'llama-3-8b');
+        assert(unloadLog.length === 0, '[mock][F-2d] no unload on first model load');
+
+        // Switch to model-B within the same provider: should unload model-A
+        await localProviderLifecycle.beforeExecution(ollama, 'qwen-2.5-7b');
+        assert(unloadLog.length === 1, '[mock][F-2d] one unload after switching from llama-3-8b to qwen-2.5-7b');
+        assert(unloadLog[0].reason === 'same-provider-model-switch', '[mock][F-2d] reason is same-provider-model-switch');
+        assert(unloadLog[0].modelId === 'llama-3-8b', '[mock][F-2d] unloaded model is llama-3-8b (the previous model)');
+
+        // Re-executing model-B (same model): should NOT trigger unload
+        await localProviderLifecycle.beforeExecution(ollama, 'qwen-2.5-7b');
+        assert(unloadLog.length === 1, '[mock][F-2d] no extra unload when re-executing the same model');
       } finally {
         _resetLocalProviderLifecycleForTests();
         _setProviderRegistryForTests(undefined);

--- a/test/modules/core/provider/local-runtime-lifecycle.test.ts
+++ b/test/modules/core/provider/local-runtime-lifecycle.test.ts
@@ -57,7 +57,7 @@ describe('localProviderLifecycle', () => {
     expect(lmStudio.releaseResources).not.toHaveBeenCalled();
   });
 
-  it('does not unload when the same local provider is reused', async () => {
+  it('unloads the previous model when switching models within the same local provider', async () => {
     const registry = new ProviderRegistry();
     const ollama = makeLocalProvider('ollama');
     registry.register(ollama);
@@ -66,6 +66,42 @@ describe('localProviderLifecycle', () => {
     await localProviderLifecycle.beforeExecution(ollama, 'qwen2.5-coder:7b');
     await localProviderLifecycle.beforeExecution(ollama, 'qwen2.5-coder:14b');
 
+    expect(ollama.releaseResources).toHaveBeenCalledTimes(1);
+    expect(ollama.releaseResources).toHaveBeenCalledWith({
+      reason: 'same-provider-model-switch',
+      modelId: 'qwen2.5-coder:7b',
+    });
+  });
+
+  it('does not unload on the very first execution (no previous model)', async () => {
+    const registry = new ProviderRegistry();
+    const ollama = makeLocalProvider('ollama');
+    registry.register(ollama);
+    _setProviderRegistryForTests(registry);
+
+    await localProviderLifecycle.beforeExecution(ollama, 'qwen2.5-coder:7b');
+
     expect(ollama.releaseResources).not.toHaveBeenCalled();
+  });
+
+  it('unloads the previous model on each same-provider switch across multiple switches', async () => {
+    const registry = new ProviderRegistry();
+    const ollama = makeLocalProvider('ollama');
+    registry.register(ollama);
+    _setProviderRegistryForTests(registry);
+
+    await localProviderLifecycle.beforeExecution(ollama, 'model-a');
+    await localProviderLifecycle.beforeExecution(ollama, 'model-b');
+    await localProviderLifecycle.beforeExecution(ollama, 'model-c');
+
+    expect(ollama.releaseResources).toHaveBeenCalledTimes(2);
+    expect(ollama.releaseResources).toHaveBeenNthCalledWith(1, {
+      reason: 'same-provider-model-switch',
+      modelId: 'model-a',
+    });
+    expect(ollama.releaseResources).toHaveBeenNthCalledWith(2, {
+      reason: 'same-provider-model-switch',
+      modelId: 'model-b',
+    });
   });
 });


### PR DESCRIPTION
### Summary
This PR implements correct unloading of models when switching between models within the same local provider, preventing VRAM bloat and resource leaks.

#### Key changes:
- **Lifecycle:** `localProviderLifecycle.beforeExecution` now detects same-provider model switches and calls `releaseResources` with `reason: 'same-provider-model-switch'`.
- **Types:** Extends `LLMProvider.releaseResources` type to include `'same-provider-model-switch'`.
- **Providers:** Updates Ollama and LM Studio provider signatures for the new type.
- **Tests:**
  - Unit: Adds/updates tests in `local-runtime-lifecycle.test.ts` for same-provider model switch behavior.
  - Operational: Updates `[mock][F-2b]` and adds `[mock][F-2d]` in `test-operational.mjs` to validate correct unloads.

Fixes #53.

---
- [x] All unit and operational tests pass
- [x] Build passes
- [x] README and docs updated if needed