### PR TITLE
fix(#50): unify telemetry routing to ModelRegistry and correct preemptive heuristic bias

### DIFF
--- a/src/modules/benchmark/core/model-benchmarker.ts
+++ b/src/modules/benchmark/core/model-benchmarker.ts
@@ -367,6 +367,10 @@ export async function benchmarkModel(
       ? Math.max(0, Math.min(1, 1 - overallAvgMs / 60_000))
       : undefined;
 
+  // Carry forward the benchmark count from the existing registry entry so the
+  // model selector can apply a confidence discount on sparse data.
+  const previousCount = modelRegistry.getModel(modelId)?.benchmarkSummary?.benchmarkCount ?? 0;
+
   const registrySummary: BenchmarkSummary = {
     lastRunAt: Date.now(),
     taskCategories,
@@ -378,6 +382,7 @@ export async function benchmarkModel(
     successRate: overallSuccessRate,
     qualityScore: overallQuality,
     avgResponseTime: overallAvgMs,
+    benchmarkCount: previousCount + 1,
   };
 
   // -------------------------------------------------------------------------

--- a/src/modules/core/model/types.ts
+++ b/src/modules/core/model/types.ts
@@ -35,6 +35,12 @@ export interface BenchmarkSummary {
   successRate?: number;
   qualityScore?: number;
   avgResponseTime?: number;
+  /**
+   * Number of benchmark runs accumulated. Used by the model selector to apply
+   * a confidence discount on sparse data so that a large unbenchmarked model is
+   * not permanently blocked by a small model with a single lucky benchmark run.
+   */
+  benchmarkCount?: number;
 }
 
 export interface ModelMetadata {

--- a/src/modules/decision-engine/services/modelSelector.ts
+++ b/src/modules/decision-engine/services/modelSelector.ts
@@ -6,7 +6,7 @@ import { Model } from '../../../types/index.js';
 import { COMPLEXITY_THRESHOLDS } from '../types/index.js';
 // import { modelProfiles } from '../utils/modelProfiles.js';
 import { isOpenRouterConfigured } from '../../api-integration/tool-definition/index.js';
-import { isProviderId, isProviderLocal } from '../../core/provider/index.js';
+import { isProviderLocal } from '../../core/provider/index.js';
 import { getModelRegistry } from '../../core/model/index.js';
 
 function getTaskCategoryScore(modelId: string, taskCategory?: string): number | undefined {
@@ -24,6 +24,44 @@ function getTaskCategoryScore(modelId: string, taskCategory?: string): number | 
       return scores.speed;
     default:
       return undefined;
+  }
+}
+
+/**
+ * Compute a size-based heuristic score for a local model.
+ *
+ * For complex tasks, larger models score higher; for simple tasks, smaller
+ * models score higher (faster, fewer resources). Scores are calibrated so
+ * that a large unbenchmarked model (e.g. 70B) outscores a small model (e.g.
+ * 2B) with a single sparse benchmark run when confidence-blended (issue #50).
+ */
+function computeLocalModelHeuristicScore(modelId: string, complexity: number): number {
+  // Normalise the model id for size-pattern matching.
+  // Gemma 3n uses "e2b" / "e4b" (Efficient N-Billion) — treat them as
+  // equivalent to plain "2b" / "4b" for scoring purposes.
+  const normalizedId = modelId.toLowerCase()
+    .replace(/:e(\d+)b\b/, ':$1b')
+    .replace(/\be(\d+)b\b/, '$1b');
+
+  if (complexity >= COMPLEXITY_THRESHOLDS.MEDIUM) {
+    // Complex tasks: larger models are strongly preferred
+    if (/\b(70b|72b|65b)\b/.test(normalizedId)) return 0.75;
+    if (/\b(40b|41b|47b)\b/.test(normalizedId)) return 0.65;
+    if (/\b(20b|22b|27b|32b)\b/.test(normalizedId)) return 0.55;
+    if (/\b(13b|14b)\b/.test(normalizedId)) return 0.45;
+    if (/\b(7b|8b|9b|10b|11b|12b)\b/.test(normalizedId)) return 0.40;
+    if (/\b(4b|5b|6b)\b/.test(normalizedId)) return 0.25;
+    if (/\b(1b|1\.5b|2b|3b)\b/.test(normalizedId)) return 0.15;
+    return 0.30; // unknown size — moderate
+  } else {
+    // Simple tasks: smaller models are preferred (fast and resource-efficient)
+    if (/\b(1b|1\.5b|2b)\b/.test(normalizedId)) return 0.75;
+    if (/\b(3b|4b)\b/.test(normalizedId)) return 0.65;
+    if (/\b(5b|6b|7b)\b/.test(normalizedId)) return 0.50;
+    if (/\b(8b|9b|10b|11b|12b)\b/.test(normalizedId)) return 0.35;
+    if (/\b(13b|14b)\b/.test(normalizedId)) return 0.25;
+    if (/\b(20b|22b|27b|32b|40b|65b|70b|72b)\b/.test(normalizedId)) return 0.15;
+    return 0.30; // unknown size — moderate
   }
 }
 
@@ -57,8 +95,17 @@ export const modelSelector = {
   },
 
   /**
-   * Get the best local model for a task
-   * Uses metrics like success rate, quality, speed for selection
+   * Get the best local model for a task.
+   *
+   * Reads benchmark data exclusively from the ModelRegistry (the single
+   * authoritative telemetry source per issue #50). ModelRegistry is updated
+   * by both benchmarkModel() (in-process, immediately) and
+   * modelsDb.seedModelRegistry() (on startup from persisted JSON), so it
+   * always reflects the most current data.
+   *
+   * Sparse benchmark data (< 3 runs) is blended with a size-based heuristic
+   * using a confidence factor to prevent a small model with a single lucky
+   * benchmark run from permanently out-scoring a large, highly-capable model.
    */
   async getBestLocalModel(
     complexity: number,
@@ -67,9 +114,6 @@ export const modelSelector = {
     taskCategory?: string,
   ): Promise<Model | null> {
     try {
-      // Get the models database
-      const modelsDb = modelsDbService.getDatabase();
-
       // Get local models
       const localModels = await costMonitor.getAvailableModels();
       const filteredLocalModels = localModels.filter(model =>
@@ -77,143 +121,86 @@ export const modelSelector = {
         (model.contextWindow === undefined || model.contextWindow >= totalTokens) &&
         model.id !== excludeId
       );
-      
+
       if (filteredLocalModels.length === 0) {
         return null;
       }
-      
-      // Find the best model based on our database and complexity
+
+      // Number of benchmark runs required before empirical data is treated as
+      // fully reliable. Below this, scores are blended with the size heuristic.
+      const RELIABLE_BENCHMARK_COUNT = 3;
+
       let bestModel: Model | null = null;
       let bestScore = 0;
-      
+
       for (const model of filteredLocalModels) {
-        // Calculate a base score for this model
         let score = 0;
-        
-        // Check if we have performance data for this model
-        const modelData = modelsDb.models[model.id] as unknown as {
-          benchmarkCount: number;
-          successRate: number;
-          qualityScore: number;
-          avgResponseTime: number;
-          complexityScore: number;
-        };
-        
-        if (modelData && modelData.benchmarkCount > 0) {
-          // Calculate score based on performance data
-          // Weight factors based on importance - same as free model selection
-          const successRateWeight = 0.3;
-          const qualityScoreWeight = 0.4;
-          const responseTimeWeight = 0.3; // Increased weight for speed
-          const complexityMatchWeight = 0.1;
-          
-          // Success rate factor (0-1)
-          score += modelData.successRate * successRateWeight;
 
-          // Prefer task-category benchmark score when available; otherwise use
-          // the generic quality score from modelsDb.
+        // Read benchmark data from ModelRegistry — the single authoritative source.
+        const benchmarkSummary = getModelRegistry().getModel(model.id)?.benchmarkSummary;
+
+        if (benchmarkSummary) {
+          const successRate = benchmarkSummary.successRate ?? 0;
+
+          // Prefer task-category benchmark score when available (e.g. code score
+          // for a code task); fall back to the overall quality score.
           const taskCategoryScore = getTaskCategoryScore(model.id, taskCategory);
-          const qualitySignal = taskCategoryScore ?? modelData.qualityScore;
-          score += qualitySignal * qualityScoreWeight;
-          
-          // Response time factor (0-1, inversely proportional)
-          // Normalize response time: faster is better
-          // Assume 15000ms (15s) is the upper bound for response time
-          const responseTimeFactor = Math.max(0, 1 - (modelData.avgResponseTime / 15000));
-          score += responseTimeFactor * responseTimeWeight;
-          
-          // Complexity match factor (0-1)
-          // How well does the model's complexity score match the requested complexity?
-          const complexityMatchFactor = 1 - Math.abs(modelData.complexityScore - complexity);
-          score += complexityMatchFactor * complexityMatchWeight;
-          
-          logger.debug(`Local model ${model.id} has performance data: success=${modelData.successRate.toFixed(2)}, quality=${qualitySignal.toFixed(2)}${taskCategoryScore !== undefined ? ` (task:${taskCategory})` : ''}, time=${modelData.avgResponseTime}ms, score=${score.toFixed(2)}`);
-          
-          // For local models, we also consider system resource usage
-          // This is a local-specific optimization
-          if (isProviderId(model.provider, 'local') || isProviderId(model.provider, 'lm-studio')) {
-            // Prefer models that use fewer resources for the same quality
-            // This is a heuristic based on model size
-            if (model.id.toLowerCase().includes('1.5b') || 
-                model.id.toLowerCase().includes('1b') ||
-                model.id.toLowerCase().includes('3b')) {
-              score += 0.1; // Small models use fewer resources
-            }
-          }
+          const qualitySignal = taskCategoryScore ?? (benchmarkSummary.qualityScore ?? 0);
+
+          const avgResponseTime = benchmarkSummary.avgResponseTime ?? 0;
+          const responseTimeFactor = Math.max(0, 1 - (avgResponseTime / 15000));
+
+          // Empirical score (max ≈ 1.0)
+          const empiricalScore =
+            successRate * 0.3 +
+            qualitySignal * 0.4 +
+            responseTimeFactor * 0.3;
+
+          // Confidence reflects how much we trust sparse benchmark data.
+          // A single run on a small model can produce numbers that outclass a
+          // large model, but may not be representative. Blend with the
+          // size-based heuristic until we have enough runs.
+          const benchmarkCount = benchmarkSummary.benchmarkCount ?? 1;
+          const confidence = Math.min(1, benchmarkCount / RELIABLE_BENCHMARK_COUNT);
+          const heuristicScore = computeLocalModelHeuristicScore(model.id, complexity);
+
+          score = empiricalScore * confidence + heuristicScore * (1 - confidence);
+
+          logger.debug(
+            `Local model ${model.id} has benchmark data: ` +
+            `success=${successRate.toFixed(2)}, ` +
+            `quality=${qualitySignal.toFixed(2)}${taskCategoryScore !== undefined ? ` (task:${taskCategory})` : ''}, ` +
+            `time=${avgResponseTime.toFixed(0)}ms, runs=${benchmarkCount}, ` +
+            `confidence=${confidence.toFixed(2)}, score=${score.toFixed(2)}`,
+          );
         } else {
-          // No performance data, use heuristics based on model size
-          
-          // Prefer models with "instruct" in the name for instruction-following tasks
+          // No benchmark data — rely entirely on size-based heuristics.
+          score = computeLocalModelHeuristicScore(model.id, complexity);
+
+          // Small bonus for instruct-tuned models (better instruction following).
           if (model.id.toLowerCase().includes('instruct')) {
-            score += 0.1;
+            score += 0.05;
           }
 
-          // Normalise the model id for size-pattern matching.
-          // Gemma 3n uses "e2b" / "e4b" (Efficient N-Billion) — treat them as
-          // equivalent to plain "2b" / "4b" for scoring purposes.
-          const normalizedId = model.id.toLowerCase()
-            .replace(/:e(\d+)b\b/, ':$1b')   // gemma3n:e2b → gemma3n:2b
-            .replace(/\be(\d+)b\b/, '$1b');   // standalone e2b → 2b
-
-          // For complex tasks, prefer larger models
-          if (complexity >= COMPLEXITY_THRESHOLDS.MEDIUM) {
-            // Check for model size indicators in the name
-            if (normalizedId.includes('70b') || 
-                normalizedId.includes('65b') || 
-                normalizedId.includes('40b') ||
-                normalizedId.includes('32b') ||
-                normalizedId.includes('27b') ||
-                normalizedId.includes('20b')) {
-              score += 0.3; // Very large models
-            } else if (normalizedId.includes('13b') || 
-                       normalizedId.includes('14b') || 
-                       normalizedId.includes('7b') ||
-                       normalizedId.includes('8b') ||
-                       normalizedId.includes('9b') ||
-                       normalizedId.includes('12b')) {
-              score += 0.2; // Medium-sized models
-            } else if (normalizedId.includes('3b') || 
-                       normalizedId.includes('4b') || 
-                       normalizedId.includes('2b') || 
-                       normalizedId.includes('1.5b') || 
-                       normalizedId.includes('1b')) {
-              score += 0.1; // Smaller models
-            }
-          } else {
-            // For simpler tasks, prefer smaller, more efficient models
-            if (normalizedId.includes('1.5b') || 
-                normalizedId.includes('1b') ||
-                normalizedId.includes('2b') ||
-                normalizedId.includes('3b') ||
-                normalizedId.includes('4b')) {
-              score += 0.3; // Smaller models are more efficient
-            } else if (normalizedId.includes('7b') || 
-                       normalizedId.includes('8b') ||
-                       normalizedId.includes('9b') ||
-                       normalizedId.includes('12b')) {
-              score += 0.2; // Medium models
-            } else {
-              // Large models (20b+) get 0.1 — usable but not preferred for simple tasks
-              score += 0.1;
-            }
-          }
-          
-          logger.debug(`Local model ${model.id} has no performance data, using heuristics: score=${score.toFixed(2)}`);
+          logger.debug(
+            `Local model ${model.id} has no benchmark data, using heuristics: score=${score.toFixed(2)}`,
+          );
         }
-        
-        // Update best model if this one has a higher score
+
         if (score > bestScore) {
           bestScore = score;
           bestModel = model;
         }
       }
-      
-      // If we couldn't find a best model based on scores, fall back to default
+
+      // Fall back to first available model if scoring produced no winner
       if (!bestModel && filteredLocalModels.length > 0) {
         bestModel = filteredLocalModels[0];
       }
-      
-      logger.debug(`Selected best local model for complexity ${complexity.toFixed(2)} and ${totalTokens} tokens: ${bestModel?.id}`);
+
+      logger.debug(
+        `Selected best local model for complexity ${complexity.toFixed(2)} and ${totalTokens} tokens: ${bestModel?.id}`,
+      );
       return bestModel;
     } catch (error) {
       logger.error('Error getting best local model:', error);

--- a/src/modules/decision-engine/services/modelsDb.ts
+++ b/src/modules/decision-engine/services/modelsDb.ts
@@ -16,6 +16,7 @@ function toBenchmarkSummary(data: ModelPerformanceData): BenchmarkSummary {
     successRate: data.successRate,
     qualityScore: data.qualityScore,
     avgResponseTime: data.avgResponseTime,
+    benchmarkCount: data.benchmarkCount,
   };
 }
 

--- a/test/modules/decision-engine/modelSelector.registry-routing.test.ts
+++ b/test/modules/decision-engine/modelSelector.registry-routing.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Tests for issue #50 — Unify telemetry routing reads from ModelRegistry and
+ * correct preemptive heuristic bias.
+ *
+ * Key acceptance criteria validated here:
+ *  1. getBestLocalModel reads benchmark data from ModelRegistry (not modelsDb JSON).
+ *  2. A large unbenchmarked model (70B) wins over a small model (2B) with a
+ *     single benchmark run for complex tasks when quality is prioritised.
+ *  3. Once a model has reliable benchmark data (≥ 3 runs), empirical scores
+ *     drive selection over heuristics.
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+// ---------------------------------------------------------------------------
+// Infrastructure mocks — must be declared before any dynamic imports
+// ---------------------------------------------------------------------------
+
+jest.unstable_mockModule('../../../dist/utils/logger.js', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const mockGetAvailableModels = jest
+  .fn<() => Promise<Array<{ id: string; provider: string; contextWindow: number }>>>()
+  .mockResolvedValue([]);
+
+jest.unstable_mockModule('../../../dist/modules/cost-monitor/index.js', () => ({
+  costMonitor: {
+    getAvailableModels: mockGetAvailableModels,
+    getFreeModels: jest.fn().mockResolvedValue([]),
+  },
+}));
+
+// modelsDb is mocked empty to prove getBestLocalModel no longer relies on it
+// for benchmark data.
+const mockGetDatabase = jest.fn(() => ({ models: {} }));
+jest.unstable_mockModule(
+  '../../../dist/modules/decision-engine/services/modelsDb.js',
+  () => ({
+    modelsDbService: {
+      getDatabase: mockGetDatabase,
+    },
+  }),
+);
+
+// ModelRegistry mock — the single authoritative source under test.
+const mockGetModel = jest.fn<
+  (modelId: string) =>
+    | {
+        benchmarkSummary?: {
+          benchmarkCount?: number;
+          successRate?: number;
+          qualityScore?: number;
+          avgResponseTime?: number;
+          scores?: { code?: number };
+          lastRunAt?: number;
+          taskCategories?: string[];
+        };
+      }
+    | undefined
+>(() => undefined);
+
+jest.unstable_mockModule('../../../dist/modules/core/model/index.js', () => ({
+  getModelRegistry: () => ({
+    getModel: mockGetModel,
+  }),
+}));
+
+jest.unstable_mockModule('../../../dist/modules/openrouter/index.js', () => ({
+  openRouterModule: {
+    modelTracking: { models: {} },
+    initialize: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.unstable_mockModule(
+  '../../../dist/modules/api-integration/tool-definition/index.js',
+  () => ({
+    isOpenRouterConfigured: () => false,
+  }),
+);
+
+jest.unstable_mockModule('../../../dist/modules/core/provider/index.js', () => ({
+  isProviderId: jest.fn().mockReturnValue(false),
+  isProviderLocal: jest
+    .fn()
+    .mockImplementation(
+      (provider: string) =>
+        provider === 'ollama' || provider === 'lm-studio' || provider === 'local',
+    ),
+}));
+
+// ---------------------------------------------------------------------------
+// Module under test (loaded after mocks)
+// ---------------------------------------------------------------------------
+
+const { modelSelector } = await import(
+  '../../../dist/modules/decision-engine/services/modelSelector.js'
+);
+const { COMPLEXITY_THRESHOLDS } = await import(
+  '../../../dist/modules/decision-engine/types/index.js'
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal BenchmarkSummary for the registry mock. */
+function makeBenchmarkSummary(overrides: {
+  benchmarkCount?: number;
+  successRate?: number;
+  qualityScore?: number;
+  avgResponseTime?: number;
+  scores?: { code?: number; reasoning?: number; speed?: number };
+}) {
+  return {
+    lastRunAt: Date.now(),
+    taskCategories: ['code', 'chat'],
+    scores: overrides.scores ?? {},
+    benchmarkCount: overrides.benchmarkCount ?? 1,
+    successRate: overrides.successRate ?? 0.8,
+    qualityScore: overrides.qualityScore ?? 0.8,
+    avgResponseTime: overrides.avgResponseTime ?? 1000,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('modelSelector.getBestLocalModel — issue #50 registry unification', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: modelsDb is empty — proves we do NOT rely on it
+    mockGetDatabase.mockReturnValue({ models: {} });
+  });
+
+  // ── Slice 1: Heuristic bias correction (tracer bullet) ───────────────────
+
+  describe('heuristic bias correction', () => {
+    it('selects 70B unbenchmarked model over 2B model with 1 benchmark run for complex tasks', async () => {
+      // Two models: a large 70B with no benchmark data and a tiny 2B with one
+      // moderate benchmark run. For a complex task, the 70B should win.
+      // We populate modelsDb with the 2B data so the current code takes the
+      // empirical path — that is the exact bias the fix must overcome.
+      mockGetAvailableModels.mockResolvedValue([
+        { id: 'llama3-70b', provider: 'ollama', contextWindow: 8192 },
+        { id: 'qwen-2b', provider: 'ollama', contextWindow: 8192 },
+      ]);
+
+      // Populate BOTH modelsDb and registry so both old and new code paths see the same data.
+      mockGetDatabase.mockReturnValue({
+        models: {
+          'qwen-2b': {
+            benchmarkCount: 1,
+            successRate: 0.75,
+            qualityScore: 0.65,
+            avgResponseTime: 2000,
+            complexityScore: 0.3,
+          },
+        },
+      });
+
+      mockGetModel.mockImplementation((id: string) => {
+        if (id === 'qwen-2b') {
+          return {
+            benchmarkSummary: makeBenchmarkSummary({
+              benchmarkCount: 1,
+              successRate: 0.75,
+              qualityScore: 0.65,
+              avgResponseTime: 2000,
+            }),
+          };
+        }
+        return undefined; // llama3-70b has no benchmark data
+      });
+
+      // Complex task — well above MEDIUM threshold
+      const complexity = COMPLEXITY_THRESHOLDS.MEDIUM + 0.1;
+      const selected = await modelSelector.getBestLocalModel(complexity, 500);
+      expect(selected?.id).toBe('llama3-70b');
+    });
+
+    it('selects 70B unbenchmarked over 2B with 1 benchmark even when 2B metrics look good', async () => {
+      mockGetAvailableModels.mockResolvedValue([
+        { id: 'llama3-70b', provider: 'ollama', contextWindow: 8192 },
+        { id: 'phi-2b', provider: 'ollama', contextWindow: 8192 },
+      ]);
+
+      // Populate modelsDb so the old code path takes the empirical route for phi-2b.
+      mockGetDatabase.mockReturnValue({
+        models: {
+          'phi-2b': {
+            benchmarkCount: 1,
+            successRate: 0.95,
+            qualityScore: 0.90,
+            avgResponseTime: 500,
+            complexityScore: 0.3,
+          },
+        },
+      });
+
+      // 2B has impressive-looking single-run metrics (could be lucky)
+      mockGetModel.mockImplementation((id: string) => {
+        if (id === 'phi-2b') {
+          return {
+            benchmarkSummary: makeBenchmarkSummary({
+              benchmarkCount: 1,
+              successRate: 0.95,
+              qualityScore: 0.90,
+              avgResponseTime: 500,
+            }),
+          };
+        }
+        return undefined;
+      });
+
+      const selected = await modelSelector.getBestLocalModel(
+        COMPLEXITY_THRESHOLDS.COMPLEX + 0.05, // very complex
+        500,
+      );
+      expect(selected?.id).toBe('llama3-70b');
+    });
+
+    it('prefers small model over large for simple tasks (no benchmark data)', async () => {
+      mockGetAvailableModels.mockResolvedValue([
+        { id: 'llama3-70b', provider: 'ollama', contextWindow: 8192 },
+        { id: 'phi-2b', provider: 'ollama', contextWindow: 8192 },
+      ]);
+      // Neither has benchmark data
+      mockGetModel.mockReturnValue(undefined);
+
+      const selected = await modelSelector.getBestLocalModel(
+        COMPLEXITY_THRESHOLDS.SIMPLE - 0.05, // simple task
+        200,
+      );
+      expect(selected?.id).toBe('phi-2b');
+    });
+  });
+
+  // ── Slice 2: Data source unification ─────────────────────────────────────
+
+  describe('data source unification — reads from ModelRegistry', () => {
+    it('uses registry benchmark data to score a model even when modelsDb is empty', async () => {
+      // bench-7b has high benchmark data ONLY in the registry (not in modelsDb).
+      // basic-70b has no data anywhere.
+      // bench-7b should win because the registry data is the source of truth.
+      mockGetAvailableModels.mockResolvedValue([
+        { id: 'basic-70b', provider: 'ollama', contextWindow: 8192 },
+        { id: 'bench-7b', provider: 'ollama', contextWindow: 8192 },
+      ]);
+
+      // modelsDb is empty (default from beforeEach)
+      mockGetModel.mockImplementation((id: string) => {
+        if (id === 'bench-7b') {
+          return {
+            benchmarkSummary: makeBenchmarkSummary({
+              benchmarkCount: 5, // reliable data
+              successRate: 0.95,
+              qualityScore: 0.95,
+              avgResponseTime: 800,
+            }),
+          };
+        }
+        return undefined; // basic-70b has no registry entry
+      });
+
+      // Complex task: without the fix, basic-70b wins via heuristics (0.3) over
+      // bench-7b (heuristic 0.2, because modelsDb empty). With the fix, bench-7b
+      // reads from registry and scores ~0.91 (fully confident), beating basic-70b.
+      const selected = await modelSelector.getBestLocalModel(
+        COMPLEXITY_THRESHOLDS.MEDIUM + 0.1,
+        500,
+      );
+      expect(selected?.id).toBe('bench-7b');
+    });
+
+    it('avoids a model whose code score is 0 in the registry for code tasks', async () => {
+      mockGetAvailableModels.mockResolvedValue([
+        { id: 'weak-coder-7b', provider: 'ollama', contextWindow: 8192 },
+        { id: 'strong-coder-7b', provider: 'ollama', contextWindow: 8192 },
+      ]);
+
+      mockGetModel.mockImplementation((id: string) => {
+        if (id === 'weak-coder-7b') {
+          return {
+            benchmarkSummary: makeBenchmarkSummary({
+              benchmarkCount: 3,
+              successRate: 0.8,
+              qualityScore: 0.8,
+              avgResponseTime: 1000,
+              scores: { code: 0.0 }, // zero code score
+            }),
+          };
+        }
+        if (id === 'strong-coder-7b') {
+          return {
+            benchmarkSummary: makeBenchmarkSummary({
+              benchmarkCount: 3,
+              successRate: 0.8,
+              qualityScore: 0.8,
+              avgResponseTime: 1000,
+              scores: { code: 0.9 }, // strong code score
+            }),
+          };
+        }
+        return undefined;
+      });
+
+      const selected = await modelSelector.getBestLocalModel(0.5, 500, undefined, 'code');
+      expect(selected?.id).toBe('strong-coder-7b');
+    });
+  });
+
+  // ── Slice 3: Reliable data overrides heuristics ───────────────────────────
+
+  describe('reliable benchmark data drives selection', () => {
+    it('a well-benchmarked 7B model beats an unbenchmarked 70B for complex tasks', async () => {
+      mockGetAvailableModels.mockResolvedValue([
+        { id: 'llama3-70b', provider: 'ollama', contextWindow: 8192 },
+        { id: 'codellama-7b', provider: 'ollama', contextWindow: 8192 },
+      ]);
+
+      // codellama-7b has reliable data (≥3 runs) with high scores
+      mockGetModel.mockImplementation((id: string) => {
+        if (id === 'codellama-7b') {
+          return {
+            benchmarkSummary: makeBenchmarkSummary({
+              benchmarkCount: 3,
+              successRate: 0.95,
+              qualityScore: 0.95,
+              avgResponseTime: 600,
+            }),
+          };
+        }
+        return undefined; // llama3-70b has no benchmark data
+      });
+
+      const selected = await modelSelector.getBestLocalModel(
+        COMPLEXITY_THRESHOLDS.MEDIUM + 0.1,
+        500,
+      );
+      // codellama-7b's empirical score (~0.95) beats llama3-70b's heuristic (~0.75)
+      expect(selected?.id).toBe('codellama-7b');
+    });
+
+    it('a 70B model with reliable benchmarks beats a 2B model with 1 run', async () => {
+      mockGetAvailableModels.mockResolvedValue([
+        { id: 'llama3-70b', provider: 'ollama', contextWindow: 8192 },
+        { id: 'phi-2b', provider: 'ollama', contextWindow: 8192 },
+      ]);
+
+      mockGetModel.mockImplementation((id: string) => {
+        if (id === 'llama3-70b') {
+          return {
+            benchmarkSummary: makeBenchmarkSummary({
+              benchmarkCount: 3,
+              successRate: 0.85,
+              qualityScore: 0.85,
+              avgResponseTime: 3000,
+            }),
+          };
+        }
+        if (id === 'phi-2b') {
+          return {
+            benchmarkSummary: makeBenchmarkSummary({
+              benchmarkCount: 1,
+              successRate: 0.9,
+              qualityScore: 0.9,
+              avgResponseTime: 300,
+            }),
+          };
+        }
+        return undefined;
+      });
+
+      const selected = await modelSelector.getBestLocalModel(
+        COMPLEXITY_THRESHOLDS.MEDIUM + 0.1,
+        500,
+      );
+      expect(selected?.id).toBe('llama3-70b');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #50 by unifying local-model benchmark reads to ModelRegistry and correcting heuristic bias for sparse benchmark data.

## What changed

- Switched local model selection to read benchmark telemetry from ModelRegistry (single authoritative in-process source).
- Added benchmarkCount to benchmark summaries and propagated it through registry updates.
- Implemented confidence blending for sparse benchmark data:
  - confidence = min(1, benchmarkCount / 3)
  - score = empiricalScore * confidence + heuristicScore * (1 - confidence)
- Recalibrated local-model heuristics to prevent under-benchmarked small models from permanently blocking large models on complex tasks.
- Added focused TDD coverage for issue #50 behavior and data-source guarantees.

## Files changed

- src/modules/core/model/types.ts
- src/modules/decision-engine/services/modelsDb.ts
- src/modules/benchmark/core/model-benchmarker.ts
- src/modules/decision-engine/services/modelSelector.ts
- test/modules/decision-engine/modelSelector.registry-routing.test.ts

## Validation

- Build: passed
- Tests: 45 suites passed, 298 tests passed

Closes #50