### PR TITLE
[codex] Consolidate free model benchmarking

### DIFF
--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -38,6 +38,7 @@ and this file for the current snapshot.
 - OpenRouter Axios error logging now redacts credential-bearing request details as of 2026-05-20; logs keep response status/body summaries without serializing the original Axios request config.
 - Issue #32 was accidentally merged to `main` via PR #35 with no implementation diff. A fresh `future-testing` implementation was completed as of 2026-05-20: `route_task` queues a persistent Task/Job and returns `task_id` immediately; callers poll `get_task_status` or use `cancel_task`.
 - Issue #34 dashboard implementation moved from blocked intent to active baseline as of 2026-05-20: the web UI now supports manual `route_task` submission, task/job cancellation, benchmark history, and queue/task monitoring with server-side filters, pagination, queue-position range, and ETA fields (`eta_ms`/`eta`).
+- Issue #51 is implemented as of 2026-05-20: MCP `benchmark_free_models` now uses the modular benchmark engine, writes free-model results through `benchmarks.db`, and returns structured provider/rate-limit errors instead of delegating to the legacy decision-engine benchmark service.
 
 ## What to keep out of docs
 

--- a/docs/history/memory-bank/sessionLog.md
+++ b/docs/history/memory-bank/sessionLog.md
@@ -122,3 +122,20 @@ Verification:
 
 Follow-ups:
 - Live LLM poll-to-completion acceptance is still blocked in this environment because the configured Ollama endpoint is unavailable.
+
+## 2026-05-20 - Issue #51 Modular Free Benchmarking
+
+Author: Codex
+
+Summary:
+- Moved the MCP `benchmark_free_models` path from the legacy decision-engine benchmark service to the modular benchmark engine.
+- Added `benchmarkModule.benchmarkFreeModels`, which enumerates healthy OpenRouter free models, runs provider-backed benchmarks, and persists results through `benchmarkDb`.
+- Added `BenchmarkProviderError` so rate limits and provider failures propagate as structured MCP error payloads instead of being silently swallowed.
+- Marked the legacy `benchmarkService.benchmarkFreeModels()` method deprecated for remaining internal callers.
+
+Verification:
+- `npm run build` passes.
+- Focused Jest run passes: `test/modules/benchmark/index.test.ts`, `test/modules/benchmark/free-models.test.ts`, `test/modules/api-integration/openrouter-integration.test.ts`, and `test/dispatcher.test.ts`.
+
+Follow-ups:
+- Full live OpenRouter benchmarking was not run in this pass to avoid paid/free-provider side effects; use an explicit operational run when provider credentials and rate budget are available.

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { checkForUpdates, runUpdate, runStartupCheck } from './modules/updater/i
 import { getJobTrackerSync } from './modules/decision-engine/services/jobTracker.js';
 import { ContextWindowError } from './modules/api-integration/task-execution/index.js';
 import { InferenceTimeoutError } from './modules/utils/inferenceTimeout.js';
+import { BenchmarkProviderError } from './modules/benchmark/core/runner.js';
 import { reloadConfig } from './config/index.js';
 
 // Get the current file's directory path in ES modules
@@ -495,6 +496,21 @@ export class LocalLamaMcpServer {
                     message: error.message,
                     providerId: error.providerId,
                     timeoutMs: error.timeoutMs,
+                  }),
+                }],
+                isError: true,
+              };
+            }
+            if (error instanceof BenchmarkProviderError) {
+              return {
+                content: [{
+                  type: 'text' as const,
+                  text: JSON.stringify({
+                    error: error.code,
+                    message: error.message,
+                    providerId: error.providerId,
+                    modelId: error.modelId,
+                    retryAfterMs: error.retryAfterMs,
                   }),
                 }],
                 isError: true,

--- a/src/modules/api-integration/openrouter-integration/index.ts
+++ b/src/modules/api-integration/openrouter-integration/index.ts
@@ -1,6 +1,6 @@
 import { config } from '../../../config/index.js';
 import { logger } from '../../../utils/logger.js';
-import { 
+import {
     IOpenRouterIntegration, 
     OpenRouterBenchmarkConfig, 
     OpenRouterBenchmarkResult, 
@@ -10,7 +10,7 @@ import {
     // ModelBenchmarkResult 
 } from './types.js';
 import { openRouterModule } from '../../openrouter/index.js';
-import { benchmarkService } from '../../decision-engine/services/benchmarkService.js';
+import { benchmarkModule } from '../../benchmark/index.js';
 
 export class OpenRouterIntegration implements IOpenRouterIntegration {
   /**
@@ -100,21 +100,9 @@ export class OpenRouterIntegration implements IOpenRouterIntegration {
   /**
    * Benchmark free models available from OpenRouter
    */
-  async benchmarkFreeModels(_benchmarkConfig: OpenRouterBenchmarkConfig): Promise<OpenRouterBenchmarkResult> {
-    logger.info('Forwarding benchmark request to benchmarkService');
-    // TODO: Implement proper benchmarking using _benchmarkConfig
-    await benchmarkService.benchmarkFreeModels();
-    
-    // Return a simplified result since the full implementation is in benchmarkService
-    return {
-      results: {},
-      summary: {
-        bestQualityModel: 'unknown',
-        bestSpeedModel: 'unknown',
-        totalTime: 0,
-        modelsCount: 0
-      }
-    };
+  async benchmarkFreeModels(benchmarkConfig: OpenRouterBenchmarkConfig): Promise<OpenRouterBenchmarkResult> {
+    logger.info('Forwarding benchmark_free_models request to modular benchmark engine');
+    return await benchmarkModule.benchmarkFreeModels(benchmarkConfig);
   }
 }
 

--- a/src/modules/benchmark/core/runner.ts
+++ b/src/modules/benchmark/core/runner.ts
@@ -6,11 +6,43 @@ import { BenchmarkConfig, BenchmarkResult, BenchmarkRunResult, Model, BenchmarkT
 import { simulateGenericApi } from '../api/simulation.js';
 import { evaluateQuality } from '../evaluation/quality.js';
 import { codeEvaluationService } from '../../decision-engine/services/codeEvaluationService.js';
-import { saveBenchmarkResult, getRecentModelResults } from '../storage/benchmarkDb.js';
+import { initBenchmarkDb, saveBenchmarkResult, getRecentModelResults } from '../storage/benchmarkDb.js';
 import { isProviderLocal, getProviderRegistry } from '../../core/provider/index.js';
 
 // Track model failure counts in memory
 const modelFailures = new Map<string, number>();
+
+export class BenchmarkProviderError extends Error {
+  constructor(
+    public readonly code: 'benchmark_rate_limited' | 'benchmark_provider_error',
+    public readonly providerId: string,
+    public readonly modelId: string,
+    message: string,
+    public readonly retryAfterMs?: number,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'BenchmarkProviderError';
+  }
+
+  static from(error: unknown, providerId: string, modelId: string): BenchmarkProviderError {
+    const message = error instanceof Error ? error.message : String(error);
+    const retryMatch = message.match(/retry after\s+(\d+)\s*s/i);
+    const retryAfterMs = retryMatch ? Number(retryMatch[1]) * 1000 : undefined;
+    const isRateLimit =
+      /rate\s*limit|too many requests/i.test(message) ||
+      (typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === 429);
+
+    return new BenchmarkProviderError(
+      isRateLimit ? 'benchmark_rate_limited' : 'benchmark_provider_error',
+      providerId,
+      modelId,
+      message,
+      retryAfterMs,
+      error
+    );
+  }
+}
 
 // Track model failure and get count
 function trackModelFailure(modelId: string): number {
@@ -56,7 +88,8 @@ export async function runModelBenchmark(
   task: string,
   contextLength: number,
   expectedOutputLength: number,
-  config: BenchmarkConfig
+  config: BenchmarkConfig,
+  options: { failFastProviderErrors?: boolean } = {}
 ): Promise<{
   timeTaken: number;
   successRate: number;
@@ -125,6 +158,9 @@ export async function runModelBenchmark(
         } catch (err) {
           const errorMessage = err instanceof Error ? err.message : String(err);
           logger.warn(`Provider ${model.provider} executeTask failed for ${model.id}: ${errorMessage}`);
+          if (options.failFastProviderErrors) {
+            throw BenchmarkProviderError.from(err, model.provider, model.id);
+          }
           runOutput = `Benchmark run failed for ${model.id}: ${errorMessage}`;
         }
       } else {
@@ -204,6 +240,9 @@ export async function runModelBenchmark(
       tokenUsage.total += promptTokens + completionTokens;
       
     } catch (error) {
+      if (options.failFastProviderErrors && error instanceof BenchmarkProviderError) {
+        throw error;
+      }
       logger.error(`Error in run ${i + 1} for ${model.id}:`, error);
       
       // Still add the failed run to the results
@@ -464,6 +503,187 @@ export async function benchmarkTask(
   }
   
   return result;
+}
+
+export interface BenchmarkFreeModelsParams {
+  tasks: Array<Omit<BenchmarkTaskParams, 'expectedOutputLength' | 'complexity'> & {
+    expectedOutputLength?: number;
+    complexity?: number;
+  }>;
+  runsPerTask?: number;
+  parallel?: boolean;
+  maxParallelTasks?: number;
+  taskTimeout?: number;
+  saveResults?: boolean;
+}
+
+export interface BenchmarkFreeModelsResult {
+  results: Record<string, {
+    averageTime: number;
+    successRate: number;
+    averageQuality: number;
+    successfulTasks: number;
+    totalTasks: number;
+  }>;
+  summary: {
+    bestQualityModel: string;
+    bestSpeedModel: string;
+    totalTime: number;
+    modelsCount: number;
+    tasksCount: number;
+    runsCount: number;
+  };
+}
+
+function emptyModelResult() {
+  return {
+    model: 'none',
+    timeTaken: 0,
+    successRate: 0,
+    qualityScore: 0,
+    tokenUsage: { prompt: 0, completion: 0, total: 0 },
+    cost: 0,
+    output: ''
+  };
+}
+
+function resultTaskId(taskId: string, modelId: string): string {
+  return `${taskId}-${modelId.replace(/[^a-z0-9]/gi, '_')}`;
+}
+
+/**
+ * Benchmark currently healthy OpenRouter free models through the modular
+ * provider-backed runner and persist each run to benchmarkDb.
+ */
+export async function benchmarkFreeModels(params: BenchmarkFreeModelsParams): Promise<BenchmarkFreeModelsResult> {
+  const config: BenchmarkConfig = {
+    ...appConfig.benchmark,
+    runsPerTask: params.runsPerTask ?? appConfig.benchmark.runsPerTask,
+    parallel: params.parallel ?? appConfig.benchmark.parallel,
+    maxParallelTasks: params.maxParallelTasks ?? appConfig.benchmark.maxParallelTasks,
+    taskTimeout: params.taskTimeout ?? appConfig.benchmark.taskTimeout,
+    saveResults: params.saveResults ?? appConfig.benchmark.saveResults,
+  };
+
+  await initBenchmarkDb();
+  const freeModels = await costMonitor.getFreeModels(true);
+  if (freeModels.length === 0 || params.tasks.length === 0) {
+    return {
+      results: {},
+      summary: {
+        bestQualityModel: 'none',
+        bestSpeedModel: 'none',
+        totalTime: 0,
+        modelsCount: freeModels.length,
+        tasksCount: params.tasks.length,
+        runsCount: 0,
+      },
+    };
+  }
+
+  const perModel = new Map<string, {
+    totalTime: number;
+    totalQuality: number;
+    successfulTasks: number;
+    totalTasks: number;
+  }>();
+
+  for (const model of freeModels) {
+    const provider = getProviderRegistry().get(model.provider);
+    if (!provider) {
+      throw new BenchmarkProviderError(
+        'benchmark_provider_error',
+        model.provider,
+        model.id,
+        `No registered provider '${model.provider}' is available for benchmark_free_models`
+      );
+    }
+
+    const stats = {
+      totalTime: 0,
+      totalQuality: 0,
+      successfulTasks: 0,
+      totalTasks: 0,
+    };
+
+    for (const task of params.tasks) {
+      const expectedOutputLength = task.expectedOutputLength ?? 512;
+      const complexity = task.complexity ?? 0.5;
+      const run = await runModelBenchmark(
+        'paid',
+        model,
+        task.task,
+        task.contextLength,
+        expectedOutputLength,
+        config,
+        { failFastProviderErrors: true }
+      );
+
+      stats.totalTime += run.timeTaken;
+      stats.totalQuality += run.qualityScore;
+      stats.successfulTasks += run.successRate > 0 ? 1 : 0;
+      stats.totalTasks += 1;
+
+      if (config.saveResults) {
+        await saveBenchmarkResult({
+          taskId: resultTaskId(task.taskId, model.id),
+          task: task.task,
+          contextLength: task.contextLength,
+          outputLength: run.tokenUsage.completion || expectedOutputLength,
+          complexity,
+          local: emptyModelResult(),
+          paid: {
+            model: model.id,
+            timeTaken: run.timeTaken,
+            successRate: run.successRate,
+            qualityScore: run.qualityScore,
+            tokenUsage: run.tokenUsage,
+            cost: run.tokenUsage.prompt * (model.costPerToken?.prompt || 0) +
+              run.tokenUsage.completion * (model.costPerToken?.completion || 0),
+            output: run.output || '',
+            runs: run.runs,
+          },
+          timestamp: new Date().toISOString(),
+        });
+      }
+    }
+
+    perModel.set(model.id, stats);
+  }
+
+  const results: BenchmarkFreeModelsResult['results'] = {};
+  for (const [modelId, stats] of perModel) {
+    results[modelId] = {
+      averageTime: stats.totalTasks > 0 ? stats.totalTime / stats.totalTasks : 0,
+      successRate: stats.totalTasks > 0 ? stats.successfulTasks / stats.totalTasks : 0,
+      averageQuality: stats.totalTasks > 0 ? stats.totalQuality / stats.totalTasks : 0,
+      successfulTasks: stats.successfulTasks,
+      totalTasks: stats.totalTasks,
+    };
+  }
+
+  const entries = Object.entries(results);
+  const bestQualityModel = entries.reduce(
+    (best, current) => current[1].averageQuality > best[1].averageQuality ? current : best,
+    entries[0]
+  )?.[0] ?? 'none';
+  const bestSpeedModel = entries.reduce(
+    (best, current) => current[1].averageTime < best[1].averageTime ? current : best,
+    entries[0]
+  )?.[0] ?? 'none';
+  const totalTime = entries.reduce((sum, [, result]) => sum + result.averageTime * result.totalTasks, 0);
+
+  return {
+    results,
+    summary: {
+      bestQualityModel,
+      bestSpeedModel,
+      totalTime,
+      modelsCount: freeModels.length,
+      tasksCount: params.tasks.length,
+      runsCount: entries.reduce((sum, [, result]) => sum + result.totalTasks, 0),
+    },
+  };
 }
 
 export function getDynamicTimeout(modelId: string, contextWindow: number = 4096, taskComplexity: number = 0.5): number {

--- a/src/modules/benchmark/index.ts
+++ b/src/modules/benchmark/index.ts
@@ -2,7 +2,7 @@ import { config } from '../../config/index.js';
 import { BenchmarkConfig, BenchmarkTaskParams } from '../../types/index.js';
 
 // Import core functionality
-import { benchmarkTask } from './core/runner.js';
+import { benchmarkTask, benchmarkFreeModels } from './core/runner.js';
 import { generateSummary } from './core/summary.js';
 
 // Import API integrations
@@ -71,6 +71,7 @@ export const benchmarkModule = {
   defaultConfig,
   benchmarkTask,
   benchmarkTasks,
+  benchmarkFreeModels,
   generateSummary,
   
   // API integrations

--- a/src/modules/decision-engine/services/benchmarkService.ts
+++ b/src/modules/decision-engine/services/benchmarkService.ts
@@ -557,6 +557,10 @@ export const benchmarkService = {
    * Benchmark all available free models
    * This helps us gather performance data for all free models
    * to make better decisions in the future
+   *
+   * @deprecated MCP `benchmark_free_models` now uses
+   * `src/modules/benchmark/core/runner.ts#benchmarkFreeModels`, which writes to
+   * benchmarkDb and propagates structured provider errors.
    */
   async benchmarkFreeModels(): Promise<void> {
     if (benchmarkState.isRateLimited) {

--- a/test/dispatcher.test.ts
+++ b/test/dispatcher.test.ts
@@ -177,6 +177,11 @@ const mockBenchmarkTasks = jest.fn<() => Promise<{ taskCount: number; local: { a
     local: { avgSuccessRate: 0.76 },
     paid: { avgSuccessRate: 0 },
   });
+const mockBenchmarkFreeModels = jest.fn<() => Promise<{ results: Record<string, unknown>; summary: { modelsCount: number } }>>()
+  .mockResolvedValue({
+    results: {},
+    summary: { modelsCount: 0 },
+  });
 
 const mockDefaultBenchmarkConfig = {
   runsPerTask: 1,
@@ -193,6 +198,12 @@ jest.unstable_mockModule('../dist/modules/benchmark/index.js', () => ({
     benchmarkTask: mockBenchmarkTask,
     benchmarkTasks: mockBenchmarkTasks,
   },
+}));
+
+jest.unstable_mockModule('../dist/modules/api-integration/openrouter-integration/index.js', () => ({
+  benchmarkFreeModels: mockBenchmarkFreeModels,
+  getFreeModels: jest.fn().mockResolvedValue([]),
+  updatePromptingStrategy: jest.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -255,6 +266,21 @@ jest.unstable_mockModule('../dist/modules/api-integration/task-execution/index.j
   },
 }));
 
+jest.unstable_mockModule('../dist/modules/benchmark/core/runner.js', () => ({
+  BenchmarkProviderError: class BenchmarkProviderError extends Error {
+    constructor(
+      public code: string,
+      public providerId: string,
+      public modelId: string,
+      message: string,
+      public retryAfterMs?: number,
+    ) {
+      super(message);
+      this.name = 'BenchmarkProviderError';
+    }
+  },
+}));
+
 // ---------------------------------------------------------------------------
 // Module under test
 // ---------------------------------------------------------------------------
@@ -301,6 +327,7 @@ describe('LocalLamaMcpServer tool dispatcher', () => {
     mockReloadConfig.mockClear();
     mockBenchmarkTask.mockClear();
     mockBenchmarkTasks.mockClear();
+    mockBenchmarkFreeModels.mockClear();
     mockGetMonitoringInfo.mockClear();
     mockIsAlertActive.mockReturnValue(false);
     mockBuildQueueAlert.mockResolvedValue(null);
@@ -675,6 +702,92 @@ describe('LocalLamaMcpServer tool dispatcher', () => {
       maxParallelTasks: 2,
       taskTimeout: 480000,
       saveResults: true,
+    });
+  });
+
+  it('routes benchmark_free_models to the OpenRouter integration', async () => {
+    if (!capturedHandler) throw new Error('handler not registered');
+
+    await capturedHandler(
+      {
+        params: {
+          name: 'benchmark_free_models',
+          arguments: {
+            tasks: [
+              {
+                task_id: 'benchmark-free-models',
+                task: 'Write a small TypeScript memoization helper.',
+                context_length: 300,
+                expected_output_length: 120,
+                complexity: 0.4,
+              },
+            ],
+            runs_per_task: 1,
+            parallel: false,
+            max_parallel_tasks: 1,
+          },
+        },
+      },
+      {},
+    );
+
+    expect(mockBenchmarkFreeModels).toHaveBeenCalledWith({
+      tasks: [
+        {
+          taskId: 'benchmark-free-models',
+          task: 'Write a small TypeScript memoization helper.',
+          contextLength: 300,
+          expectedOutputLength: 120,
+          complexity: 0.4,
+          localModel: undefined,
+          paidModel: undefined,
+        },
+      ],
+      runsPerTask: 1,
+      parallel: false,
+      maxParallelTasks: 1,
+    });
+  });
+
+  it('returns a structured benchmark_rate_limited body from benchmark_free_models', async () => {
+    if (!capturedHandler) throw new Error('handler not registered');
+    const { BenchmarkProviderError } = await import('../dist/modules/benchmark/core/runner.js');
+    mockBenchmarkFreeModels.mockRejectedValueOnce(
+      new BenchmarkProviderError(
+        'benchmark_rate_limited',
+        'openrouter',
+        'openrouter/free-code',
+        'OpenRouter rate limit reached (10 calls/min). Retry after 60s.',
+        60000,
+      ),
+    );
+
+    const result = await capturedHandler(
+      {
+        params: {
+          name: 'benchmark_free_models',
+          arguments: {
+            tasks: [
+              {
+                task_id: 'rate-limit-case',
+                task: 'Write a JavaScript add function.',
+                context_length: 80,
+              },
+            ],
+          },
+        },
+      },
+      {},
+    );
+
+    const typed = result as { content: { type: string; text: string }[]; isError?: boolean };
+    expect(typed.isError).toBe(true);
+    const parsed = JSON.parse(typed.content[0].text);
+    expect(parsed).toMatchObject({
+      error: 'benchmark_rate_limited',
+      providerId: 'openrouter',
+      modelId: 'openrouter/free-code',
+      retryAfterMs: 60000,
     });
   });
 

--- a/test/modules/api-integration/openrouter-integration.test.ts
+++ b/test/modules/api-integration/openrouter-integration.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const benchmarkFreeModelsMock = jest.fn();
+
+jest.unstable_mockModule('../../../dist/config/index.js', () => ({
+  config: {
+    openRouterApiKey: 'test-key'
+  }
+}));
+
+jest.unstable_mockModule('../../../dist/utils/logger.js', () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn()
+  }
+}));
+
+jest.unstable_mockModule('../../../dist/modules/openrouter/index.js', () => ({
+  openRouterModule: {
+    modelTracking: { models: {} },
+    initialize: jest.fn(),
+    executeTask: jest.fn(),
+    clearTrackingData: jest.fn(),
+    getFreeModels: jest.fn().mockResolvedValue([]),
+    updatePromptingStrategy: jest.fn()
+  }
+}));
+
+jest.unstable_mockModule('../../../dist/modules/benchmark/index.js', () => ({
+  benchmarkModule: {
+    benchmarkFreeModels: benchmarkFreeModelsMock
+  }
+}));
+
+jest.unstable_mockModule('../../../dist/modules/decision-engine/services/benchmarkService.js', () => {
+  throw new Error('legacy benchmarkService should not be imported by openrouter-integration');
+});
+
+const { benchmarkFreeModels } = await import('../../../dist/modules/api-integration/openrouter-integration/index.js');
+
+describe('openrouter-integration benchmarkFreeModels', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    benchmarkFreeModelsMock.mockResolvedValue({
+      results: {},
+      summary: {
+        bestQualityModel: 'none',
+        bestSpeedModel: 'none',
+        totalTime: 0,
+        modelsCount: 0,
+        tasksCount: 0,
+        runsCount: 0
+      }
+    });
+  });
+
+  it('delegates benchmark_free_models to the modular benchmark engine', async () => {
+    const result = await benchmarkFreeModels({
+      tasks: [
+        {
+          taskId: 'free-model-api',
+          task: 'Write a TypeScript debounce helper.',
+          contextLength: 120,
+          expectedOutputLength: 60,
+          complexity: 0.3
+        }
+      ],
+      runsPerTask: 1,
+      parallel: false,
+      maxParallelTasks: 1
+    });
+
+    expect(benchmarkFreeModelsMock).toHaveBeenCalledWith({
+      tasks: [
+        {
+          taskId: 'free-model-api',
+          task: 'Write a TypeScript debounce helper.',
+          contextLength: 120,
+          expectedOutputLength: 60,
+          complexity: 0.3
+        }
+      ],
+      runsPerTask: 1,
+      parallel: false,
+      maxParallelTasks: 1
+    });
+    expect(result.summary.modelsCount).toBe(0);
+  });
+});

--- a/test/modules/benchmark/free-models.test.ts
+++ b/test/modules/benchmark/free-models.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const getFreeModelsMock = jest.fn();
+const executeTaskMock = jest.fn();
+const initBenchmarkDbMock = jest.fn();
+const saveBenchmarkResultMock = jest.fn();
+const getRecentModelResultsMock = jest.fn();
+
+jest.unstable_mockModule('../../../dist/modules/cost-monitor/index.js', () => ({
+  costMonitor: {
+    getFreeModels: getFreeModelsMock,
+    getAvailableModels: jest.fn().mockResolvedValue([])
+  }
+}));
+
+jest.unstable_mockModule('../../../dist/modules/core/provider/index.js', () => ({
+  getProviderRegistry: jest.fn(() => ({
+    get: jest.fn((providerId: string) => providerId === 'openrouter'
+      ? {
+          id: 'openrouter',
+          executeTask: executeTaskMock
+        }
+      : undefined)
+  })),
+  isProviderLocal: jest.fn((providerId: string) => providerId === 'ollama' || providerId === 'lm-studio')
+}));
+
+jest.unstable_mockModule('../../../dist/modules/benchmark/storage/benchmarkDb.js', () => ({
+  initBenchmarkDb: initBenchmarkDbMock,
+  saveBenchmarkResult: saveBenchmarkResultMock,
+  getRecentModelResults: getRecentModelResultsMock
+}));
+
+jest.unstable_mockModule('../../../dist/modules/decision-engine/services/codeEvaluationService.js', () => ({
+  codeEvaluationService: {
+    evaluateCodeQuality: jest.fn()
+  }
+}));
+
+const { benchmarkFreeModels } = await import('../../../dist/modules/benchmark/core/runner.js');
+
+describe('benchmarkFreeModels', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    initBenchmarkDbMock.mockResolvedValue(undefined);
+    getRecentModelResultsMock.mockResolvedValue(null);
+    getFreeModelsMock.mockResolvedValue([]);
+    executeTaskMock.mockResolvedValue({
+      content: 'function add(a, b) { return a + b; }',
+      model: 'openrouter/free-code',
+      promptTokens: 10,
+      completionTokens: 20
+    });
+  });
+
+  it('benchmarks free models through the modular runner and stores results in benchmarkDb', async () => {
+    getFreeModelsMock.mockResolvedValue([
+      {
+        id: 'openrouter/free-code',
+        name: 'Free Code',
+        provider: 'openrouter',
+        contextWindow: 4096,
+        capabilities: { chat: true, completion: true },
+        costPerToken: { prompt: 0, completion: 0 }
+      }
+    ]);
+
+    const result = await benchmarkFreeModels({
+      tasks: [
+        {
+          taskId: 'free-model-smoke',
+          task: 'Write a JavaScript add function.',
+          contextLength: 80,
+          expectedOutputLength: 40,
+          complexity: 0.2
+        }
+      ],
+      runsPerTask: 1,
+      parallel: false,
+      maxParallelTasks: 1
+    });
+
+    expect(getFreeModelsMock).toHaveBeenCalledWith(true);
+    expect(executeTaskMock).toHaveBeenCalledWith(
+      'openrouter/free-code',
+      'Write a JavaScript add function.',
+      expect.objectContaining({ timeoutMs: expect.any(Number) })
+    );
+    expect(saveBenchmarkResultMock).toHaveBeenCalledTimes(1);
+    expect(saveBenchmarkResultMock).toHaveBeenCalledWith(expect.objectContaining({
+      taskId: 'free-model-smoke-openrouter_free_code',
+      paid: expect.objectContaining({
+        model: 'openrouter/free-code',
+        successRate: 1
+      })
+    }));
+    expect(result.summary).toMatchObject({
+      modelsCount: 1,
+      tasksCount: 1,
+      runsCount: 1
+    });
+    expect(result.results['openrouter/free-code']).toMatchObject({
+      successfulTasks: 1,
+      totalTasks: 1,
+      successRate: 1
+    });
+  });
+
+  it('propagates rate-limit failures as structured benchmark provider errors', async () => {
+    getFreeModelsMock.mockResolvedValue([
+      {
+        id: 'openrouter/free-code',
+        name: 'Free Code',
+        provider: 'openrouter',
+        contextWindow: 4096,
+        capabilities: { chat: true, completion: true },
+        costPerToken: { prompt: 0, completion: 0 }
+      }
+    ]);
+    executeTaskMock.mockRejectedValue(new Error('OpenRouter rate limit reached (10 calls/min). Retry after 60s.'));
+
+    await expect(benchmarkFreeModels({
+      tasks: [
+        {
+          taskId: 'rate-limit-case',
+          task: 'Write a JavaScript add function.',
+          contextLength: 80,
+          expectedOutputLength: 40,
+          complexity: 0.2
+        }
+      ]
+    })).rejects.toMatchObject({
+      name: 'BenchmarkProviderError',
+      code: 'benchmark_rate_limited',
+      providerId: 'openrouter',
+      modelId: 'openrouter/free-code'
+    });
+
+    expect(saveBenchmarkResultMock).not.toHaveBeenCalled();
+  });
+});

--- a/test/modules/benchmark/index.test.ts
+++ b/test/modules/benchmark/index.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const benchmarkTaskMock = jest.fn();
+const benchmarkFreeModelsMock = jest.fn();
 const generateSummaryMock = jest.fn();
 const initBenchmarkDbMock = jest.fn();
 const cleanupOldResultsMock = jest.fn();
 
 jest.unstable_mockModule('../../../dist/modules/benchmark/core/runner.js', () => ({
-  benchmarkTask: benchmarkTaskMock
+  benchmarkTask: benchmarkTaskMock,
+  benchmarkFreeModels: benchmarkFreeModelsMock
 }));
 
 jest.unstable_mockModule('../../../dist/modules/benchmark/core/summary.js', () => ({
@@ -43,6 +45,7 @@ describe('benchmarkModule', () => {
   it('should have the expected structure', () => {
     expect(benchmarkModule).toHaveProperty('defaultConfig');
     expect(benchmarkModule).toHaveProperty('benchmarkTask');
+    expect(benchmarkModule).toHaveProperty('benchmarkFreeModels');
     expect(benchmarkModule).toHaveProperty('benchmarkTasks');
     expect(benchmarkModule).toHaveProperty('generateSummary');
     expect(benchmarkModule).toHaveProperty('api');
@@ -76,4 +79,5 @@ describe('benchmarkModule', () => {
     expect(cleanupOldResultsMock).toHaveBeenCalledTimes(1);
     expect(summary).toEqual(mockSummary);
   });
+
 });


### PR DESCRIPTION
## Summary

- Moves MCP `benchmark_free_models` off the legacy decision-engine benchmark service and onto the modular benchmark engine.
- Adds `benchmarkModule.benchmarkFreeModels` for provider-backed OpenRouter free-model runs that persist through `benchmarks.db`.
- Adds structured `BenchmarkProviderError` handling so rate limits/provider failures return MCP `isError` JSON instead of being swallowed.
- Marks the legacy `benchmarkService.benchmarkFreeModels()` method deprecated for remaining internal callers.

Closes #51.

## Validation

- `npm test` passes: 47 suites / 303 tests.