### PR TITLE
docs: clarify server-local monitoring URLs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,6 +70,22 @@ _Avoid_: Resume, restart, replay
 A notification surfaced to the user or MCP client at startup when the Job Queue contains Jobs that need attention (recovering, queued-but-stale, or permanently failed). Lets the agent decide early whether to cancel, re-queue, or wait. Also triggered mid-session when any Job transitions to `failed` or `permanently_failed`, so the agent is notified on the next tool call without explicit polling. The alert clears automatically when no `failed` or `permanently_failed` Jobs remain — healthy queued/in_progress Jobs do not sustain it. Future: explicit acknowledgement via tool call for sessions with large decomposed refactors.
 _Avoid_: Startup warning, notification, banner
 
+**Ambient metadata field**:
+A top-level response field attached to MCP tool results when server context must be surfaced without a separate polling call. Ambient metadata fields are additive and optional, and should remain top-level for consistency (for example `_queue_alert`).
+_Avoid_: Nested metadata envelope, inline prose-only warning
+
+**Server reminder**:
+An ambient metadata field that surfaces a low-frequency prompt about optional monitoring setup. The reminder is cadence-gated per server process instance, emitted by a single winner under concurrent calls, and attached to both successful and handled-error tool responses across all tools when eligible.
+_Avoid_: Per-call spam, transport-level crash guarantees
+
+**Monitoring reachability state**:
+The reminder's normalized status for monitoring endpoint checks: `reachable`, `unreachable`, or `unknown` when no conclusive probe result exists yet.
+_Avoid_: Boolean-only status, ad-hoc freeform strings
+
+**Non-blocking reminder path**:
+Reminder attachment behavior that must not wait on outbound reachability probes before returning a tool response.
+_Avoid_: Synchronous probe on request path, latency-coupled reminder injection
+
 **WebSocket side channel**:
 The secondary real-time channel (ws://localhost:808x) that broadcasts Job progress updates. Complements, but does not replace, the primary MCP tool response path.
 _Avoid_: WebSocket server (ambiguous — the side channel is a specific role, not just a server)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,7 +59,7 @@ _Avoid_: Evaluation, test run, assessment
 ### Monitoring
 
 **Dashboard**:
-A planned web interface for observing the Job Queue, reviewing Benchmark results, and submitting Tasks manually. Not yet built; monitoring currently flows through the WebSocket side channel.
+A web interface for observing the Job Queue, reviewing Benchmark results, and submitting Tasks manually. It is optional and server-local like the WebSocket side channel, so remote users may need port forwarding before opening it from another machine.
 _Avoid_: UI, frontend, portal, monitor
 
 **Job Recovery**:
@@ -82,12 +82,16 @@ _Avoid_: Per-call spam, transport-level crash guarantees
 The reminder's normalized status for monitoring endpoint checks: `reachable`, `unreachable`, or `unknown` when no conclusive probe result exists yet.
 _Avoid_: Boolean-only status, ad-hoc freeform strings
 
+**Server-local monitoring endpoint**:
+A monitoring URL emitted in MCP metadata that is resolved from the machine running the MCP server, not the machine running the MCP client. Typical examples are `monitoring.websocketUrl` and the optional dashboard URL. In remote environments, callers may need SSH, container, Codespaces, or WSL port forwarding before these URLs are reachable.
+_Avoid_: Globally reachable URL, client-local URL
+
 **Non-blocking reminder path**:
 Reminder attachment behavior that must not wait on outbound reachability probes before returning a tool response.
 _Avoid_: Synchronous probe on request path, latency-coupled reminder injection
 
 **WebSocket side channel**:
-The secondary real-time channel (ws://localhost:808x) that broadcasts Job progress updates. Complements, but does not replace, the primary MCP tool response path.
+The secondary real-time channel (ws://localhost:808x) that broadcasts Job progress updates. It is a server-local monitoring endpoint: remote clients may need forwarding before the URL is reachable. Complements, but does not replace, the primary MCP tool response path.
 _Avoid_: WebSocket server (ambiguous — the side channel is a specific role, not just a server)
 
 ## Example dialogue

--- a/README.md
+++ b/README.md
@@ -387,6 +387,8 @@ The server now provides job tracking resources:
 - **Job Progress**: Track the progress of a specific job via `locallama://jobs/progress/{jobId}`
 - **Job Cancellation**: Cancel a running job using the `cancel_job` tool
 
+When live monitoring is enabled, task-executing MCP tools also attach a `monitoring` object to the tool result. The URL values in that object are `scope: server-local`: they are generated from the machine running the MCP server, not from the machine running your MCP client. In local setups those are usually the same machine. In SSH, container, Codespaces, or WSL setups, you may need to forward ports before the `websocketUrl` or dashboard URL is reachable from your client.
+
 ### Using with Modern MCP Clients
 
 Build the server, then configure your MCP client to launch `node dist/index.js` with the environment variables relevant to your local setup.
@@ -501,6 +503,45 @@ The MCP server provides several ways to monitor and understand its usage:
     *   `locallama://models`: List of detected local models (LM Studio, Ollama).
     *   `locallama://openrouter/status`: Status of the OpenRouter integration.
 
+#### Monitoring Metadata Example
+
+When the JobTracker WebSocket server is running, task-executing tools can include monitoring metadata like this:
+
+```json
+{
+  "task_id": "task-123",
+  "monitoring": {
+    "websocketUrl": "ws://127.0.0.1:8081",
+    "activeJobsUri": "locallama://jobs/active",
+    "jobProgressUriTemplate": "locallama://jobs/progress/{jobId}",
+    "note": "Connect to websocketUrl for live job updates, or read activeJobsUri / jobProgressUriTemplate through MCP resources."
+  }
+}
+```
+
+Interpret the fields as follows:
+
+- `monitoring.websocketUrl`: `scope: server-local`. This is the WebSocket side channel as seen from the MCP server host. A remote client may need port forwarding before it can connect.
+- `monitoring.activeJobsUri`: MCP resource URI for the currently active job list. This is transport-stable and does not depend on HTTP/WebSocket reachability.
+- `monitoring.jobProgressUriTemplate`: MCP resource URI template for per-job progress. Replace `{jobId}` with the returned job ID.
+- `monitoring.note`: Human-readable reminder to use either the WebSocket side channel or the MCP resources.
+
+#### Remote Access Troubleshooting
+
+If your MCP client is not running on the same machine as the server, use one of these patterns:
+
+- SSH host: forward the server-local WebSocket port, and optionally the dashboard port, to your local machine.
+
+```bash
+ssh -L 8081:127.0.0.1:8081 -L 3001:127.0.0.1:3001 your-user@your-server
+```
+
+- Dev Containers or Codespaces: forward port `8081` for live job updates and optionally port `3001` for the dashboard. Use the VS Code Ports view or your Codespaces port-forwarding workflow.
+- WSL: if the MCP client runs inside the same WSL distro as the server, use the returned `websocketUrl` directly. If the client runs on Windows while the server runs in WSL, forward port `8081` and optionally `3001` through VS Code or another local tunnel before connecting.
+- Containerized server: treat `127.0.0.1` as container-local. Publish or forward the WebSocket port from the container namespace before trying to connect from outside the container.
+
+The WebSocket side channel is optional. You can always fall back to `locallama://jobs/active` and `locallama://jobs/progress/{jobId}` through MCP resources even when no forwarded WebSocket path is available.
+
 By utilizing these resources and checking the logs, users and LLMs interacting with the server can gain insights into its operation, costs, and performance, including the advanced optimizations happening within the local model modules.
 
 ### Running Benchmarks
@@ -526,6 +567,8 @@ Benchmark results are stored in the `benchmark-results` directory and include:
 When the server is running, a dashboard is available at:
 
 `http://localhost:3001`
+
+This dashboard is optional. It consumes the same server-local monitoring surfaces as the WebSocket side channel, but the MCP resources remain the primary transport-neutral monitoring path. In remote setups, treat `http://localhost:3001` as `scope: server-local` and forward port `3001` if you want to open it from another machine.
 
 The dashboard provides:
 

--- a/docs/adr/0001-non-blocking-route-task-with-persistent-job-queue.md
+++ b/docs/adr/0001-non-blocking-route-task-with-persistent-job-queue.md
@@ -10,6 +10,8 @@ Jobs found in `in_progress` state at startup are automatically retried once. The
 
 At startup, if any Jobs are queued, recovering, or permanently failed, the server emits a Boot-time Alert so the user or MCP client can decide early what to do with them. The Alert surfaces on two channels: a terminal log line (visible when the server is run manually) and a `_queue_alert` metadata field on every subsequent MCP tool response until the queue is clear. The ambient metadata approach ensures MCP clients (Claude Code, OpenCode, etc.) cannot miss it without requiring them to call a dedicated status tool.
 
+When live monitoring metadata is attached to tool responses, `monitoring.websocketUrl` is server-local by contract. It is emitted from the MCP server host and commonly uses `127.0.0.1`, so remote clients may need SSH, container, Codespaces, or WSL port forwarding before they can connect to it directly. The MCP resources (`locallama://jobs/active` and `locallama://jobs/progress/{jobId}`) remain the transport-neutral fallback, and the optional dashboard website follows the same server-local reachability rules.
+
 ## Considered options
 
 **Synchronous with hard cap** — keep blocking, fail tasks over ~90 s with a "break into smaller subtasks" error. Rejected: forces callers to decompose work the server should handle, and breaks legitimate long tasks.


### PR DESCRIPTION
Fixes #73

Clarifies that monitoring URLs are server-local to the MCP host and documents related access expectations and caveats.

Acceptance criteria covered:
- README/docs explain scope: server-local`n- remote-access troubleshooting guidance is present
- metadata field examples are up to date
- optional website/dashboard behavior is documented
- reminder cadence is only referenced where already documented