### PR TITLE
feat: add _server_reminder ambient metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,43 @@ async function attachQueueAlert(result: unknown): Promise<unknown> {
   return { result, _queue_alert: alert };
 }
 
+type ServerReminderMetadata = {
+  schemaVersion: 1;
+  kind: 'monitoring-reminder';
+  status: 'reachable' | 'unreachable' | 'unknown';
+  scope: 'server-local';
+  message: string;
+};
+
+function buildServerReminder(): ServerReminderMetadata {
+  return {
+    schemaVersion: 1,
+    kind: 'monitoring-reminder',
+    status: 'unknown',
+    scope: 'server-local',
+    message: 'Optional monitoring is available from the MCP server host. If you are working remotely, use server-local port forwarding before opening monitoring URLs.',
+  };
+}
+
+function attachServerReminder(result: unknown): unknown {
+  const reminder = buildServerReminder();
+  if (result && typeof result === 'object' && !Array.isArray(result)) {
+    return { ...result, _server_reminder: reminder };
+  }
+  return { result, _server_reminder: reminder };
+}
+
+function serializeToolPayload(result: unknown): string {
+  return typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+}
+
+function toolResponse(result: unknown, isError = false) {
+  return {
+    content: [{ type: 'text' as const, text: serializeToolPayload(result) }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
 function attachMonitoringInfo(toolName: string, result: unknown): unknown {
   if (!MONITORED_TOOL_NAMES.has(toolName)) return result;
 
@@ -464,57 +501,35 @@ export class LocalLamaMcpServer {
             // get a readable string.
             const resultWithMonitoring = attachMonitoringInfo(name, result);
             const resultWithAlert = await attachQueueAlert(resultWithMonitoring);
-            const textContent = typeof resultWithAlert === 'string'
-              ? resultWithAlert
-              : JSON.stringify(resultWithAlert, null, 2);
-            return {
-              content: [{ type: 'text' as const, text: textContent }],
-            };
+            const resultWithReminder = attachServerReminder(resultWithAlert);
+            return toolResponse(resultWithReminder);
           } catch (error) {
             logger.error(`Error executing tool ${name}:`, error);
             if (error instanceof ContextWindowError) {
-              return {
-                content: [{
-                  type: 'text' as const,
-                  text: JSON.stringify({
-                    error: 'context_overflow',
-                    message: error.message,
-                    modelId: error.modelId,
-                    estimatedTokens: error.estimatedTokens,
-                    modelContextWindow: error.modelContextWindow,
-                  }),
-                }],
-                isError: true,
-              };
+              return toolResponse(attachServerReminder({
+                error: 'context_overflow',
+                message: error.message,
+                modelId: error.modelId,
+                estimatedTokens: error.estimatedTokens,
+                modelContextWindow: error.modelContextWindow,
+              }), true);
             }
             if (error instanceof InferenceTimeoutError) {
-              return {
-                content: [{
-                  type: 'text' as const,
-                  text: JSON.stringify({
-                    error: 'inference_timeout',
-                    message: error.message,
-                    providerId: error.providerId,
-                    timeoutMs: error.timeoutMs,
-                  }),
-                }],
-                isError: true,
-              };
+              return toolResponse(attachServerReminder({
+                error: 'inference_timeout',
+                message: error.message,
+                providerId: error.providerId,
+                timeoutMs: error.timeoutMs,
+              }), true);
             }
             if (error instanceof BenchmarkProviderError) {
-              return {
-                content: [{
-                  type: 'text' as const,
-                  text: JSON.stringify({
-                    error: error.code,
-                    message: error.message,
-                    providerId: error.providerId,
-                    modelId: error.modelId,
-                    retryAfterMs: error.retryAfterMs,
-                  }),
-                }],
-                isError: true,
-              };
+              return toolResponse(attachServerReminder({
+                error: error.code,
+                message: error.message,
+                providerId: error.providerId,
+                modelId: error.modelId,
+                retryAfterMs: error.retryAfterMs,
+              }), true);
             }
             throw error;
           }

--- a/test/dispatcher.test.ts
+++ b/test/dispatcher.test.ts
@@ -588,6 +588,57 @@ describe('LocalLamaMcpServer tool dispatcher', () => {
     expect(parsed._queue_alert).toBeUndefined();
   });
 
+  it('attaches _server_reminder to successful tool responses', async () => {
+    if (!capturedHandler) throw new Error('handler not registered');
+
+    const result = await capturedHandler(
+      {
+        params: {
+          name: 'get_cost_estimate',
+          arguments: { context_length: 200 },
+        },
+      },
+      {},
+    );
+
+    const typed = result as { content: { type: string; text: string }[] };
+    const parsed = JSON.parse(typed.content[0].text);
+    expect(parsed._server_reminder).toMatchObject({
+      schemaVersion: 1,
+      kind: 'monitoring-reminder',
+      status: 'unknown',
+      scope: 'server-local',
+    });
+    expect(parsed._server_reminder.message).toContain('monitoring');
+  });
+
+  it('attaches _server_reminder to handled-error tool responses', async () => {
+    if (!capturedHandler) throw new Error('handler not registered');
+    const { ContextWindowError } = await import('../dist/modules/api-integration/task-execution/index.js');
+    mockRouteTask.mockRejectedValueOnce(new ContextWindowError('tiny-model', 42, 32));
+
+    const result = await capturedHandler(
+      {
+        params: {
+          name: 'route_task',
+          arguments: { task: 'oversized prompt', context_length: 42 },
+        },
+      },
+      {},
+    );
+
+    const typed = result as { content: { type: string; text: string }[]; isError?: boolean };
+    expect(typed.isError).toBe(true);
+    const parsed = JSON.parse(typed.content[0].text);
+    expect(parsed.error).toBe('context_overflow');
+    expect(parsed._server_reminder).toMatchObject({
+      schemaVersion: 1,
+      kind: 'monitoring-reminder',
+      status: 'unknown',
+      scope: 'server-local',
+    });
+  });
+
   it('routes benchmark_task to the benchmark module with realistic client arguments', async () => {
     if (!capturedHandler) throw new Error('handler not registered');
 


### PR DESCRIPTION
## Summary
- Adds a top-level `_server_reminder` ambient metadata field to successful tool responses
- Adds the same reminder metadata to handled error responses
- Refactors tool response serialization so normal and handled-error payloads share the same wrapping behavior

## Test Plan
- [x] npm test -- --runInBand

Closes #71