### PR TITLE
feat: gate server reminder cadence

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { ContextWindowError } from './modules/api-integration/task-execution/ind
 import { InferenceTimeoutError } from './modules/utils/inferenceTimeout.js';
 import { BenchmarkProviderError } from './modules/benchmark/core/runner.js';
 import { reloadConfig } from './config/index.js';
+import { claimServerReminderIfDue } from './modules/server-reminder/gate.js';
 
 // Get the current file's directory path in ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -76,6 +77,7 @@ function buildServerReminder(): ServerReminderMetadata {
 }
 
 function attachServerReminder(result: unknown): unknown {
+  if (!claimServerReminderIfDue()) return result;
   const reminder = buildServerReminder();
   if (result && typeof result === 'object' && !Array.isArray(result)) {
     return { ...result, _server_reminder: reminder };

--- a/src/modules/server-reminder/gate.ts
+++ b/src/modules/server-reminder/gate.ts
@@ -1,0 +1,37 @@
+export const SERVER_REMINDER_INTERVAL_MS = 30 * 60 * 1000;
+
+type ServerReminderGateOptions = {
+  intervalMs?: number;
+  now?: () => number;
+};
+
+export class ServerReminderGate {
+  private readonly intervalMs: number;
+  private readonly now: () => number;
+  private lastEmittedAt: number | null = null;
+
+  constructor(options: ServerReminderGateOptions = {}) {
+    this.intervalMs = options.intervalMs ?? SERVER_REMINDER_INTERVAL_MS;
+    this.now = options.now ?? Date.now;
+  }
+
+  claimIfDue(): boolean {
+    const currentTime = this.now();
+    if (this.lastEmittedAt !== null && currentTime - this.lastEmittedAt < this.intervalMs) {
+      return false;
+    }
+
+    this.lastEmittedAt = currentTime;
+    return true;
+  }
+}
+
+let serverReminderGate = new ServerReminderGate();
+
+export function claimServerReminderIfDue(): boolean {
+  return serverReminderGate.claimIfDue();
+}
+
+export function _resetServerReminderGateForTests(options: ServerReminderGateOptions = {}): void {
+  serverReminderGate = new ServerReminderGate(options);
+}

--- a/test/dispatcher.test.ts
+++ b/test/dispatcher.test.ts
@@ -281,6 +281,12 @@ jest.unstable_mockModule('../dist/modules/benchmark/core/runner.js', () => ({
   },
 }));
 
+const mockClaimServerReminderIfDue = jest.fn(() => true);
+
+jest.unstable_mockModule('../dist/modules/server-reminder/gate.js', () => ({
+  claimServerReminderIfDue: mockClaimServerReminderIfDue,
+}));
+
 // ---------------------------------------------------------------------------
 // Module under test
 // ---------------------------------------------------------------------------
@@ -331,6 +337,8 @@ describe('LocalLamaMcpServer tool dispatcher', () => {
     mockGetMonitoringInfo.mockClear();
     mockIsAlertActive.mockReturnValue(false);
     mockBuildQueueAlert.mockResolvedValue(null);
+    mockClaimServerReminderIfDue.mockReset();
+    mockClaimServerReminderIfDue.mockReturnValue(true);
   });
 
   it('registers a tool call handler with the MCP Server', () => {
@@ -610,6 +618,26 @@ describe('LocalLamaMcpServer tool dispatcher', () => {
       scope: 'server-local',
     });
     expect(parsed._server_reminder.message).toContain('monitoring');
+  });
+
+  it('omits _server_reminder when the reminder cadence gate is not due', async () => {
+    if (!capturedHandler) throw new Error('handler not registered');
+    mockClaimServerReminderIfDue.mockReturnValue(false);
+
+    const result = await capturedHandler(
+      {
+        params: {
+          name: 'get_cost_estimate',
+          arguments: { context_length: 200 },
+        },
+      },
+      {},
+    );
+
+    const typed = result as { content: { type: string; text: string }[] };
+    const parsed = JSON.parse(typed.content[0].text);
+    expect(mockClaimServerReminderIfDue).toHaveBeenCalledTimes(1);
+    expect(parsed._server_reminder).toBeUndefined();
   });
 
   it('attaches _server_reminder to handled-error tool responses', async () => {

--- a/test/modules/server-reminder/gate.test.ts
+++ b/test/modules/server-reminder/gate.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from '@jest/globals';
+import { ServerReminderGate } from '../../../dist/modules/server-reminder/gate.js';
+
+describe('ServerReminderGate', () => {
+  it('allows a fresh process instance to emit immediately', () => {
+    const gate = new ServerReminderGate({ now: () => 1_000 });
+
+    expect(gate.claimIfDue()).toBe(true);
+  });
+
+  it('blocks repeat emissions inside the 30-minute interval', () => {
+    let now = 1_000;
+    const gate = new ServerReminderGate({ now: () => now });
+
+    expect(gate.claimIfDue()).toBe(true);
+    now += 30 * 60 * 1_000 - 1;
+
+    expect(gate.claimIfDue()).toBe(false);
+  });
+
+  it('allows the next interaction after the 30-minute interval elapses', () => {
+    let now = 1_000;
+    const gate = new ServerReminderGate({ now: () => now });
+
+    expect(gate.claimIfDue()).toBe(true);
+    now += 30 * 60 * 1_000;
+
+    expect(gate.claimIfDue()).toBe(true);
+    expect(gate.claimIfDue()).toBe(false);
+  });
+
+  it('uses synchronous check-and-set semantics so only one concurrent caller wins', async () => {
+    let now = 1_000;
+    const gate = new ServerReminderGate({ now: () => now });
+    expect(gate.claimIfDue()).toBe(true);
+    now += 30 * 60 * 1_000;
+
+    const claims = await Promise.all(
+      Array.from({ length: 20 }, async () => gate.claimIfDue()),
+    );
+
+    expect(claims.filter(Boolean)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a per-process `ServerReminderGate` with a 30-minute default interval
- Wires `_server_reminder` attachment through the gate so repeated tool calls omit the reminder until due
- Adds unit coverage for immediate first emission, interval suppression, next-due emission, and concurrent claims

## Test Plan
- [x] npm test -- --runInBand

Closes #67