### PR TITLE
feat: cache monitoring reachability for reminders

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { InferenceTimeoutError } from './modules/utils/inferenceTimeout.js';
 import { BenchmarkProviderError } from './modules/benchmark/core/runner.js';
 import { reloadConfig } from './config/index.js';
 import { claimServerReminderIfDue } from './modules/server-reminder/gate.js';
+import { getCachedMonitoringReachability } from './modules/server-reminder/reachability.js';
 
 // Get the current file's directory path in ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -64,15 +65,40 @@ type ServerReminderMetadata = {
   status: 'reachable' | 'unreachable' | 'unknown';
   scope: 'server-local';
   message: string;
+  monitoringUrl?: string;
+  lastCheckedAt?: number;
+  reason?: string;
 };
 
+function monitoringWebsiteUrlFromWebSocket(websocketUrl: string | undefined): string | undefined {
+  if (!websocketUrl) return undefined;
+
+  try {
+    const parsed = new URL(websocketUrl);
+    if (parsed.protocol === 'ws:') parsed.protocol = 'http:';
+    if (parsed.protocol === 'wss:') parsed.protocol = 'https:';
+    return parsed.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function getMonitoringWebsiteUrl(): string | undefined {
+  const monitoring = getJobTrackerSync()?.getMonitoringInfo();
+  return monitoringWebsiteUrlFromWebSocket(monitoring?.websocketUrl);
+}
+
 function buildServerReminder(): ServerReminderMetadata {
+  const reachability = getCachedMonitoringReachability(getMonitoringWebsiteUrl());
   return {
     schemaVersion: 1,
     kind: 'monitoring-reminder',
-    status: 'unknown',
+    status: reachability.status,
     scope: 'server-local',
     message: 'Optional monitoring is available from the MCP server host. If you are working remotely, use server-local port forwarding before opening monitoring URLs.',
+    ...(reachability.status === 'reachable' && reachability.url ? { monitoringUrl: reachability.url } : {}),
+    ...(reachability.lastCheckedAt !== undefined ? { lastCheckedAt: reachability.lastCheckedAt } : {}),
+    ...(reachability.reason ? { reason: reachability.reason } : {}),
   };
 }
 

--- a/src/modules/server-reminder/reachability.ts
+++ b/src/modules/server-reminder/reachability.ts
@@ -1,0 +1,108 @@
+export type MonitoringReachabilityStatus = 'reachable' | 'unreachable' | 'unknown';
+
+export type MonitoringReachabilitySnapshot = {
+  status: MonitoringReachabilityStatus;
+  url?: string;
+  lastCheckedAt?: number;
+  reason?: string;
+};
+
+export type ReachabilityProbe = (url: string, timeoutMs: number) => Promise<boolean>;
+
+type MonitoringReachabilityCacheOptions = {
+  ttlMs?: number;
+  timeoutMs?: number;
+  now?: () => number;
+  probe?: ReachabilityProbe;
+};
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_TIMEOUT_MS = 750;
+
+async function defaultProbe(url: string, timeoutMs: number): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  timeout.unref?.();
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      signal: controller.signal,
+    });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export class MonitoringReachabilityCache {
+  private readonly ttlMs: number;
+  private readonly timeoutMs: number;
+  private readonly now: () => number;
+  private readonly probe: ReachabilityProbe;
+  private readonly entries = new Map<string, MonitoringReachabilitySnapshot>();
+  private readonly inFlight = new Set<string>();
+
+  constructor(options: MonitoringReachabilityCacheOptions = {}) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.now = options.now ?? Date.now;
+    this.probe = options.probe ?? defaultProbe;
+  }
+
+  getCachedStatus(url: string | undefined | null): MonitoringReachabilitySnapshot {
+    if (!url) {
+      return { status: 'unknown', reason: 'monitoring_url_unavailable' };
+    }
+
+    const cached = this.entries.get(url);
+    if (!cached || this.isStale(cached)) {
+      this.startProbe(url);
+    }
+
+    return this.entries.get(url) ?? {
+      status: 'unknown',
+      reason: 'probe_pending',
+    };
+  }
+
+  private isStale(snapshot: MonitoringReachabilitySnapshot): boolean {
+    if (snapshot.lastCheckedAt === undefined) return true;
+    return this.now() - snapshot.lastCheckedAt >= this.ttlMs;
+  }
+
+  private startProbe(url: string): void {
+    if (this.inFlight.has(url)) return;
+    this.inFlight.add(url);
+
+    void this.probe(url, this.timeoutMs)
+      .then((reachable) => {
+        const checkedAt = this.now();
+        this.entries.set(url, reachable
+          ? { status: 'reachable', url, lastCheckedAt: checkedAt }
+          : { status: 'unreachable', lastCheckedAt: checkedAt, reason: 'probe_failed' });
+      })
+      .catch(() => {
+        this.entries.set(url, {
+          status: 'unreachable',
+          lastCheckedAt: this.now(),
+          reason: 'probe_failed',
+        });
+      })
+      .finally(() => {
+        this.inFlight.delete(url);
+      });
+  }
+}
+
+let monitoringReachabilityCache = new MonitoringReachabilityCache();
+
+export function getCachedMonitoringReachability(url: string | undefined | null): MonitoringReachabilitySnapshot {
+  return monitoringReachabilityCache.getCachedStatus(url);
+}
+
+export function _resetMonitoringReachabilityCacheForTests(options: MonitoringReachabilityCacheOptions = {}): void {
+  monitoringReachabilityCache = new MonitoringReachabilityCache(options);
+}

--- a/test/dispatcher.test.ts
+++ b/test/dispatcher.test.ts
@@ -287,6 +287,12 @@ jest.unstable_mockModule('../dist/modules/server-reminder/gate.js', () => ({
   claimServerReminderIfDue: mockClaimServerReminderIfDue,
 }));
 
+const mockGetCachedMonitoringReachability = jest.fn<() => { status: 'reachable' | 'unreachable' | 'unknown'; url?: string; lastCheckedAt?: number; reason?: string }>(() => ({ status: 'unknown', reason: 'probe_pending' }));
+
+jest.unstable_mockModule('../dist/modules/server-reminder/reachability.js', () => ({
+  getCachedMonitoringReachability: mockGetCachedMonitoringReachability,
+}));
+
 // ---------------------------------------------------------------------------
 // Module under test
 // ---------------------------------------------------------------------------
@@ -339,6 +345,8 @@ describe('LocalLamaMcpServer tool dispatcher', () => {
     mockBuildQueueAlert.mockResolvedValue(null);
     mockClaimServerReminderIfDue.mockReset();
     mockClaimServerReminderIfDue.mockReturnValue(true);
+    mockGetCachedMonitoringReachability.mockReset();
+    mockGetCachedMonitoringReachability.mockReturnValue({ status: 'unknown', reason: 'probe_pending' });
   });
 
   it('registers a tool call handler with the MCP Server', () => {
@@ -618,6 +626,34 @@ describe('LocalLamaMcpServer tool dispatcher', () => {
       scope: 'server-local',
     });
     expect(parsed._server_reminder.message).toContain('monitoring');
+  });
+
+  it('attaches _server_reminder with cached reachable monitoring URL when available', async () => {
+    if (!capturedHandler) throw new Error('handler not registered');
+    mockGetCachedMonitoringReachability.mockReturnValue({
+      status: 'reachable',
+      url: 'http://127.0.0.1:8081/',
+      lastCheckedAt: 1234,
+    });
+
+    const result = await capturedHandler(
+      {
+        params: {
+          name: 'get_cost_estimate',
+          arguments: { context_length: 200 },
+        },
+      },
+      {},
+    );
+
+    const typed = result as { content: { type: string; text: string }[] };
+    const parsed = JSON.parse(typed.content[0].text);
+    expect(mockGetCachedMonitoringReachability).toHaveBeenCalledWith('http://127.0.0.1:8081/');
+    expect(parsed._server_reminder).toMatchObject({
+      status: 'reachable',
+      monitoringUrl: 'http://127.0.0.1:8081/',
+      lastCheckedAt: 1234,
+    });
   });
 
   it('omits _server_reminder when the reminder cadence gate is not due', async () => {

--- a/test/modules/server-reminder/reachability.test.ts
+++ b/test/modules/server-reminder/reachability.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { MonitoringReachabilityCache, type ReachabilityProbe } from '../../../dist/modules/server-reminder/reachability.js';
+
+describe('MonitoringReachabilityCache', () => {
+  it('returns immediately with unknown while scheduling the first probe', () => {
+    const probe = jest.fn<ReachabilityProbe>(() => new Promise(() => undefined));
+    const cache = new MonitoringReachabilityCache({ probe, now: () => 1_000 });
+
+    const snapshot = cache.getCachedStatus('http://127.0.0.1:8080');
+
+    expect(snapshot).toMatchObject({ status: 'unknown' });
+    expect(snapshot.url).toBeUndefined();
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(probe).toHaveBeenCalledWith('http://127.0.0.1:8080', expect.any(Number));
+  });
+
+  it('uses cached reachable status and exposes the URL after a background probe succeeds', async () => {
+    const probe = jest.fn<ReachabilityProbe>(async () => true);
+    const cache = new MonitoringReachabilityCache({ probe, now: () => 1_000 });
+
+    cache.getCachedStatus('http://127.0.0.1:8080');
+    await Promise.resolve();
+
+    const snapshot = cache.getCachedStatus('http://127.0.0.1:8080');
+
+    expect(snapshot).toMatchObject({
+      status: 'reachable',
+      url: 'http://127.0.0.1:8080',
+      lastCheckedAt: 1_000,
+    });
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses cached unreachable status without exposing the URL after a probe fails', async () => {
+    const probe = jest.fn<ReachabilityProbe>(async () => false);
+    const cache = new MonitoringReachabilityCache({ probe, now: () => 1_000 });
+
+    cache.getCachedStatus('http://127.0.0.1:8080');
+    await Promise.resolve();
+
+    const snapshot = cache.getCachedStatus('http://127.0.0.1:8080');
+
+    expect(snapshot).toMatchObject({
+      status: 'unreachable',
+      lastCheckedAt: 1_000,
+    });
+    expect(snapshot.url).toBeUndefined();
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start another probe while cached status is fresh', async () => {
+    let now = 1_000;
+    const probe = jest.fn<ReachabilityProbe>(async () => true);
+    const cache = new MonitoringReachabilityCache({ probe, now: () => now, ttlMs: 5_000 });
+
+    cache.getCachedStatus('http://127.0.0.1:8080');
+    await Promise.resolve();
+    now += 4_999;
+    cache.getCachedStatus('http://127.0.0.1:8080');
+
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a non-blocking monitoring reachability cache with bounded background probes
- Emit monitoringUrl only when cached status is reachable
- Include cached status metadata, lastCheckedAt, and fallback reason in _server_reminder

## Test Plan
- [x] npm test -- --runInBand
- [x] npm run lint

Closes #72