### PR TITLE
test: add serverReminder timing, concurrency, and error-path parity coverage

### DIFF
--- a/test/dispatcher.test.ts
+++ b/test/dispatcher.test.ts
@@ -703,6 +703,42 @@ describe('LocalLamaMcpServer tool dispatcher', () => {
     });
   });
 
+  it('keeps _server_reminder reachability fields on handled-error responses', async () => {
+    if (!capturedHandler) throw new Error('handler not registered');
+    const { InferenceTimeoutError } = await import('../dist/modules/utils/inferenceTimeout.js');
+    mockGetCachedMonitoringReachability.mockReturnValueOnce({
+      status: 'reachable',
+      url: 'http://127.0.0.1:8081/',
+      lastCheckedAt: 6789,
+    });
+    mockRouteTask.mockRejectedValueOnce(
+      new InferenceTimeoutError('openrouter', 45000, 'OpenRouter inference timed out after 45000ms.'),
+    );
+
+    const result = await capturedHandler(
+      {
+        params: {
+          name: 'route_task',
+          arguments: { task: 'timeout prompt', context_length: 200 },
+        },
+      },
+      {},
+    );
+
+    const typed = result as { content: { type: string; text: string }[]; isError?: boolean };
+    expect(typed.isError).toBe(true);
+    const parsed = JSON.parse(typed.content[0].text);
+    expect(parsed.error).toBe('inference_timeout');
+    expect(parsed._server_reminder).toMatchObject({
+      schemaVersion: 1,
+      kind: 'monitoring-reminder',
+      status: 'reachable',
+      scope: 'server-local',
+      monitoringUrl: 'http://127.0.0.1:8081/',
+      lastCheckedAt: 6789,
+    });
+  });
+
   it('routes benchmark_task to the benchmark module with realistic client arguments', async () => {
     if (!capturedHandler) throw new Error('handler not registered');
 

--- a/test/modules/server-reminder/gate.test.ts
+++ b/test/modules/server-reminder/gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { ServerReminderGate } from '../../../dist/modules/server-reminder/gate.js';
+import { ServerReminderGate, claimServerReminderIfDue, _resetServerReminderGateForTests } from '../../../dist/modules/server-reminder/gate.js';
 
 describe('ServerReminderGate', () => {
   it('allows a fresh process instance to emit immediately', () => {
@@ -40,5 +40,17 @@ describe('ServerReminderGate', () => {
     );
 
     expect(claims.filter(Boolean)).toHaveLength(1);
+  });
+
+  it('resets singleton gate state to allow immediate emission after restart', () => {
+    let now = 1_000;
+    _resetServerReminderGateForTests({ now: () => now, intervalMs: 5_000 });
+
+    expect(claimServerReminderIfDue()).toBe(true);
+    now += 1_000;
+    expect(claimServerReminderIfDue()).toBe(false);
+
+    _resetServerReminderGateForTests({ now: () => now, intervalMs: 5_000 });
+    expect(claimServerReminderIfDue()).toBe(true);
   });
 });

--- a/test/modules/server-reminder/reachability.test.ts
+++ b/test/modules/server-reminder/reachability.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { MonitoringReachabilityCache, type ReachabilityProbe } from '../../../dist/modules/server-reminder/reachability.js';
+import {
+  MonitoringReachabilityCache,
+  getCachedMonitoringReachability,
+  _resetMonitoringReachabilityCacheForTests,
+  type ReachabilityProbe,
+} from '../../../dist/modules/server-reminder/reachability.js';
+
+async function flushProbeCompletion(): Promise<void> {
+  await Promise.resolve();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
 
 describe('MonitoringReachabilityCache', () => {
   it('returns immediately with unknown while scheduling the first probe', () => {
@@ -19,7 +29,7 @@ describe('MonitoringReachabilityCache', () => {
     const cache = new MonitoringReachabilityCache({ probe, now: () => 1_000 });
 
     cache.getCachedStatus('http://127.0.0.1:8080');
-    await Promise.resolve();
+    await flushProbeCompletion();
 
     const snapshot = cache.getCachedStatus('http://127.0.0.1:8080');
 
@@ -36,7 +46,7 @@ describe('MonitoringReachabilityCache', () => {
     const cache = new MonitoringReachabilityCache({ probe, now: () => 1_000 });
 
     cache.getCachedStatus('http://127.0.0.1:8080');
-    await Promise.resolve();
+    await flushProbeCompletion();
 
     const snapshot = cache.getCachedStatus('http://127.0.0.1:8080');
 
@@ -54,10 +64,89 @@ describe('MonitoringReachabilityCache', () => {
     const cache = new MonitoringReachabilityCache({ probe, now: () => now, ttlMs: 5_000 });
 
     cache.getCachedStatus('http://127.0.0.1:8080');
-    await Promise.resolve();
+    await flushProbeCompletion();
     now += 4_999;
     cache.getCachedStatus('http://127.0.0.1:8080');
 
     expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts a new probe when cached status reaches the TTL boundary', async () => {
+    let now = 1_000;
+    const probe = jest.fn<ReachabilityProbe>(async () => true);
+    const cache = new MonitoringReachabilityCache({ probe, now: () => now, ttlMs: 5_000 });
+
+    cache.getCachedStatus('http://127.0.0.1:8080');
+    await flushProbeCompletion();
+    now += 5_000;
+    cache.getCachedStatus('http://127.0.0.1:8080');
+
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it('deduplicates concurrent callers so only one in-flight probe runs per URL', async () => {
+    const releaseProbe = Promise.withResolvers<void>();
+    const probe = jest.fn<ReachabilityProbe>(async () => {
+      await releaseProbe.promise;
+      return true;
+    });
+    const cache = new MonitoringReachabilityCache({ probe, now: () => 1_000 });
+
+    const snapshots = await Promise.all(
+      Array.from({ length: 20 }, () => Promise.resolve(cache.getCachedStatus('http://127.0.0.1:8080'))),
+    );
+
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(snapshots.every((snapshot) => snapshot.status === 'unknown')).toBe(true);
+    releaseProbe.resolve();
+    await Promise.resolve();
+  });
+
+  it('stores unreachable probe_failed status when the probe rejects', async () => {
+    const probe = jest.fn<ReachabilityProbe>(async () => {
+      throw new Error('probe failed');
+    });
+    const cache = new MonitoringReachabilityCache({ probe, now: () => 1_000 });
+
+    cache.getCachedStatus('http://127.0.0.1:8080');
+    await flushProbeCompletion();
+
+    const snapshot = cache.getCachedStatus('http://127.0.0.1:8080');
+
+    expect(snapshot).toMatchObject({
+      status: 'unreachable',
+      lastCheckedAt: 1_000,
+      reason: 'probe_failed',
+    });
+    expect(snapshot.url).toBeUndefined();
+  });
+
+  it('returns monitoring_url_unavailable and skips probing when URL is absent', () => {
+    const probe = jest.fn<ReachabilityProbe>(async () => true);
+    const cache = new MonitoringReachabilityCache({ probe, now: () => 1_000 });
+
+    const snapshot = cache.getCachedStatus(undefined);
+
+    expect(snapshot).toEqual({ status: 'unknown', reason: 'monitoring_url_unavailable' });
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('resets singleton cache state on restart so probe scheduling starts fresh', async () => {
+    const pendingProbe = Promise.withResolvers<boolean>();
+    const probe = jest.fn<ReachabilityProbe>(() => pendingProbe.promise);
+    _resetMonitoringReachabilityCacheForTests({ now: () => 1_000, probe });
+
+    const first = getCachedMonitoringReachability('http://127.0.0.1:8080');
+    const second = getCachedMonitoringReachability('http://127.0.0.1:8080');
+
+    expect(first.status).toBe('unknown');
+    expect(second.status).toBe('unknown');
+    expect(probe).toHaveBeenCalledTimes(1);
+
+    _resetMonitoringReachabilityCacheForTests({ now: () => 1_000, probe });
+    getCachedMonitoringReachability('http://127.0.0.1:8080');
+    expect(probe).toHaveBeenCalledTimes(2);
+    pendingProbe.resolve(true);
+    await flushProbeCompletion();
   });
 });


### PR DESCRIPTION
## Summary
- add serverReminder gate restart-reset coverage
- add reachability cache timing boundary (TTL), concurrency dedupe, error-path, and restart-reset tests
- add dispatcher handled-error reminder parity test for reachable metadata

## Verification
- npm run build
- node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config=jest.config.mjs test/modules/server-reminder/gate.test.ts test/modules/server-reminder/reachability.test.ts test/dispatcher.test.ts

Closes #74
