### PR TITLE
docs: Document _server_reminder metadata contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,41 @@ Interpret the fields as follows:
 - `monitoring.jobProgressUriTemplate`: MCP resource URI template for per-job progress. Replace `{jobId}` with the returned job ID.
 - `monitoring.note`: Human-readable reminder to use either the WebSocket side channel or the MCP resources.
 
+#### Server Reminder Metadata Example
+
+The server can attach a `_server_reminder` ambient metadata field to any tool response (both success and handled-error paths). This field surfaces low-frequency, non-critical information to the user or agent.
+
+```json
+{
+  "result": { "...": "..." },
+  "_server_reminder": {
+    "schemaVersion": 1,
+    "kind": "monitoring-reminder",
+    "status": "reachable",
+    "scope": "server-local",
+    "message": "Optional monitoring is available from the MCP server host. If you are working remotely, use server-local port forwarding before opening monitoring URLs.",
+    "monitoringUrl": "http://127.0.0.1:3001",
+    "lastCheckedAt": 1747699200000
+  }
+}
+```
+
+- `_server_reminder`: The top-level field name for the ambient metadata.
+- `schemaVersion`: Currently `1`.
+- `kind`: Currently `monitoring-reminder`.
+- `status`: The reachability of the monitoring dashboard URL. One of `reachable`, `unreachable`, or `unknown`.
+- `scope`: Always `server-local`, indicating the `monitoringUrl` is resolved from the server's host.
+- `message`: A human-readable explanation of the reminder.
+- `monitoringUrl`: The URL for the web dashboard. Only present when `status` is `reachable`.
+- `lastCheckedAt`: A Unix millisecond timestamp of when the reachability probe last ran.
+
+**Behavior:**
+
+- **Cadence**: The reminder is emitted at most once every 30 minutes per server process instance. An atomic, in-memory gate prevents spamming. The cadence timer resets on server restart.
+- **Delivery**: The reminder is attached to both successful and handled-error tool responses when it is due. It is not guaranteed to be delivered if the server crashes or the transport connection fails fatally.
+- **Non-blocking**: The reachability probe for the dashboard URL is non-blocking and uses a cached status. A tool call will not be delayed waiting for a probe to complete.
+- **Remote Access**: As with the `monitoring.websocketUrl`, the `monitoringUrl` is `scope: server-local`. Clients on different machines (SSH, containers, Codespaces, WSL) may need to forward the port (default `3001`) before the URL is accessible.
+
 #### Remote Access Troubleshooting
 
 If your MCP client is not running on the same machine as the server, use one of these patterns:

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -185,6 +185,14 @@ function parseNumber(value: string | undefined, defaultValue: number, min?: numb
   return num;
 }
 
+function resolvePath(envPath: string | undefined, defaultPath: string): string {
+    const p = envPath || defaultPath;
+    if (path.isAbsolute(p)) {
+        return p;
+    }
+    return path.join(rootDir, p);
+}
+
 function buildConfigFromEnv(env: NodeJS.ProcessEnv): Config {
   return {
     // Server configuration
@@ -231,16 +239,16 @@ function buildConfigFromEnv(env: NodeJS.ProcessEnv): Config {
       maxParallelTasks: parseInt(env.BENCHMARK_MAX_PARALLEL_TASKS || '2', 10),
       taskTimeout: parseInt(env.BENCHMARK_TASK_TIMEOUT || '60000', 10),
       saveResults: parseBool(env.BENCHMARK_SAVE_RESULTS, true),
-      resultsPath: env.BENCHMARK_RESULTS_PATH || path.join(rootDir, 'benchmark-results'),
+      resultsPath: resolvePath(env.BENCHMARK_RESULTS_PATH, 'benchmark-results'),
     },
 
     // Logging configuration
     logLevel: (env.LOG_LEVEL || 'info') as Config['logLevel'],
-    logFile: env.LOG_FILE,
+    logFile: env.LOG_FILE ? resolvePath(env.LOG_FILE, '') : undefined,
 
     // Cache settings
     cacheEnabled: parseBool(env.CACHE_ENABLED, true),
-    cacheDir: env.CACHE_DIR || path.join(rootDir, '.cache'),
+    cacheDir: resolvePath(env.CACHE_DIR, '.cache'),
     maxCacheSize: parseInt(env.MAX_CACHE_SIZE || '1073741824', 10),
 
     // Startup benchmark targets


### PR DESCRIPTION
Adds documentation for the `_server_reminder` ambient metadata field to README.md, including its schema, cadence, delivery semantics, non-blocking reachability behavior, and server-local scope.

Also fixes relative config path resolution for `BENCHMARK_RESULTS_PATH`, `LOG_FILE`, and `CACHE_DIR`, which surfaced during Windows test verification.

Verification:
- npm run build
- npm test

Closes #66