### PR TITLE
docs: add live source dev workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,5 +53,3 @@ The stdio transport ties the MCP host connection to the server process lifetime.
 ### `npm link` is Not Supported
 
 Do not use `npm link` to manage this project. The server relies on `import.meta.url` to resolve its root directory for configuration and artifacts, which `npm link` breaks by creating symlinks. Always point your MCP client directly to the `dist/index.js` file in your repository.
-
-```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to LocalLama MCP
+
+We welcome contributions to the LocalLama MCP Server! This guide provides instructions for setting up a live development environment from source.
+
+## Live Development from Source
+
+For active development, it's recommended to run the server directly from your cloned repository instead of a separate installed location. This allows you to see changes immediately after rebuilding.
+
+### 1. MCP Client Configuration (Windows Example)
+
+Configure your MCP client (e.g., Claude Code, Codex, Cursor) to launch the server from your repository's `dist` directory. The `cwd` should be the repository root, and you should set `LOCALLAMA_ROOT_DIR` to a directory *outside* your repository to keep runtime artifacts (logs, databases, lock files) separate from source code.
+
+**Example for Claude Code (`.claude.json`):**
+
+```json
+{
+  "mcpServers": {
+    "locallama-dev": {
+      "command": "node",
+      "args": ["C:\\Users\\<you>\\source\\locallama-mcp\\dist\\index.js"],
+      "cwd": "C:\\Users\\<you>\\source\\locallama-mcp",
+      "env": {
+        "LOCALLAMA_ROOT_DIR": "C:\\Users\\<you>\\locallama-dev"
+      }
+    }
+  }
+}
+```
+
+Replace the paths with the actual location of your repository and desired root directory. `LOCALLAMA_ROOT_DIR` should point to a user-local directory outside the repository.
+
+### 2. Build and Rebuild Cycle
+
+The development workflow relies on a few npm scripts:
+
+- **`npm run build`**: Compiles all TypeScript source files to JavaScript in the `dist/` directory and copies necessary non-TypeScript assets. Run this once initially.
+- **`npm run dev`**: Starts the TypeScript compiler (`tsc`) in watch mode. It will automatically recompile files in `src/` when you save changes. It also copies assets once at the start.
+
+**Important:** The `npm run dev` script **does not** start the server. You must manage the server process through your MCP client.
+
+### 3. Reloading the Server
+
+Because this project uses a stdio transport for MCP communication, there is no automatic hot-reloading of the server process when source files change.
+
+The development cycle is:
+1. Run `npm run dev` in a terminal and leave it running.
+2. Make changes to the source code in `src/`.
+3. The `tsc -w` process automatically rebuilds the changed files into `dist/`.
+4. **Manually restart the server in your MCP client** (e.g., in Claude Code, reload the MCP server from settings or restart the client session).
+
+The stdio transport ties the MCP host connection to the server process lifetime. When you reload the server, the previous session state is lost. MCP clients do not auto-reconnect to a restarted stdio subprocess; seamless hot reload is out of scope for this workflow.
+
+### `npm link` is Not Supported
+
+Do not use `npm link` to manage this project. The server relies on `import.meta.url` to resolve its root directory for configuration and artifacts, which `npm link` breaks by creating symlinks. Always point your MCP client directly to the `dist/index.js` file in your repository.
+
+```

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
   "author": "Jonathan Witmore",
   "license": "ISC",
   "scripts": {
-    "build": "tsc --project tsconfig.json && node -e \"const fs=require('fs');fs.mkdirSync('dist/utils',{recursive:true});fs.copyFileSync('src/utils/lock-file.js','dist/utils/lock-file.js');\"",
+    "build": "tsc --project tsconfig.json && npm run copy:assets",
     "start": "node dist/index.js",
-    "dev": "tsc -w & (node -e \"const fs=require('fs');fs.mkdirSync('dist/utils',{recursive:true});fs.copyFileSync('src/utils/lock-file.js','dist/utils/lock-file.js');\" && node --watch dist/index.js)",
+    "dev": "npm run copy:assets && tsc -w",
+    "copy:assets": "node scripts/copy-assets.js",
     "test": "npm run build && node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config=jest.config.mjs",
     "test:watch": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config=jest.config.mjs --watch",
     "lint": "eslint src/**/*.ts test/**/*.ts",

--- a/scripts/copy-assets.js
+++ b/scripts/copy-assets.js
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+
+const assets = [
+  {
+    src: 'src/utils/lock-file.js',
+    dest: 'dist/utils/lock-file.js',
+  },
+];
+
+for (const asset of assets) {
+  const destDir = path.dirname(asset.dest);
+  fs.mkdirSync(destDir, { recursive: true });
+  fs.copyFileSync(asset.src, asset.dest);
+  console.log(`Copied ${asset.src} to ${asset.dest}`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -729,7 +729,7 @@ export class LocalLamaMcpServer {
         logger.info(`MCP client identified: ${clientImpl.name} ${clientImpl.version ?? ''}`.trim());
       }
 
-      logger.info(`${connectionInfo} (PID: ${process.pid})`);
+      logger.info(`LocalLama MCP Server v${version} running on stdio (PID: ${process.pid})`);
       // Fire-and-forget startup update check — never blocks startup
       runStartupCheck().catch(() => undefined);
     } catch (error: unknown) {


### PR DESCRIPTION
## Summary
- add a cross-platform `copy:assets` script for runtime assets
- update `build` and `dev` scripts so `dev` only runs asset copy + `tsc -w`
- include the package version in the stdio startup log
- document the Windows live source development workflow in `CONTRIBUTING.md`

## Verification
- `npm run copy:assets`
- `npm run build`
- `npm test` (49 suites / 324 tests passing)
- Started `npm run dev` as a bounded background watcher smoke check and terminated it manually; it did not start the MCP server process.

Closes #58
