### PR TITLE
fix: benchmark_model honors requested provider_id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -474,12 +474,15 @@ export class LocalLamaMcpServer {
                   if (typeof modelId !== 'string' || !modelId) {
                     throw new Error('Invalid model_id for benchmark_model');
                   }
+                  const requestedProviderId = typeof args?.provider_id === 'string' && args.provider_id
+                    ? args.provider_id
+                    : undefined;
                   const rawCategories = args?.task_categories;
                   const taskCategories = Array.isArray(rawCategories)
                     ? rawCategories.filter((c): c is string => typeof c === 'string')
                     : undefined;
                   const { benchmarkModel } = await import('./modules/benchmark/core/model-benchmarker.js');
-                  return await benchmarkModel({ modelId, taskCategories: taskCategories as import('./modules/benchmark/core/model-benchmarker.js').TaskCategory[] | undefined });
+                  return await benchmarkModel({ modelId, providerId: requestedProviderId, taskCategories: taskCategories as import('./modules/benchmark/core/model-benchmarker.js').TaskCategory[] | undefined });
                 }
                 case 'retriv_init': {
                   const directories = args?.directories;

--- a/src/modules/api-integration/tool-definition/index.ts
+++ b/src/modules/api-integration/tool-definition/index.ts
@@ -338,6 +338,12 @@ class ToolDefinitionProvider implements IToolDefinitionProvider {
               type: 'string',
               description: 'The model id to benchmark (e.g. "qwen2.5-coder-7b")'
             },
+            provider_id: {
+              type: 'string',
+              description: 'Pin the benchmark to a specific provider (e.g. "lm_studio", "ollama"). ' +
+                'Required when the same model id exists on multiple providers. ' +
+                'The response providerId will always match this value when supplied.'
+            },
             task_categories: {
               type: 'array',
               items: {

--- a/src/modules/benchmark/core/model-benchmarker.ts
+++ b/src/modules/benchmark/core/model-benchmarker.ts
@@ -86,6 +86,8 @@ const CATEGORY_TASKS: Record<TaskCategory, CategoryTask[]> = {
 
 export interface BenchmarkModelParams {
   modelId: string;
+  /** When specified, benchmark runs exclusively on this provider. Skips registry lookup. */
+  providerId?: string;
   /** Defaults to ['code', 'chat'] when omitted. */
   taskCategories?: TaskCategory[];
 }
@@ -192,34 +194,47 @@ export async function benchmarkModel(
   // -------------------------------------------------------------------------
   let providerId: string;
   let executableModelId = modelId;
+
   const meta = modelRegistry.getModel(modelId);
-  if (meta) {
-    providerId = meta.providerId;
+
+  if (params.providerId) {
+    // Caller pinned a specific provider — validate it exists, skip registry lookup.
+    // This ensures (provider_id, model_id) is treated as a strict identity key.
+    providerId = params.providerId;
+    if (!registry.get(providerId)) {
+      throw new Error(
+        `benchmark_model: provider '${params.providerId}' is not in the registry`,
+      );
+    }
   } else {
-    // Model not in registry yet — scan providers for one that claims to support it
-    let found: string | undefined;
-    let foundModelId: string | undefined;
-    for (const provider of registry.list()) {
-      const variants = buildModelIdVariants(modelId, provider.id);
-      for (const variant of variants) {
-        const supported = await Promise.resolve(provider.supportsModel(variant));
-        if (supported) {
-          found = provider.id;
-          foundModelId = variant;
+    if (meta) {
+      providerId = meta.providerId;
+    } else {
+      // Model not in registry yet — scan providers for one that claims to support it
+      let found: string | undefined;
+      let foundModelId: string | undefined;
+      for (const provider of registry.list()) {
+        const variants = buildModelIdVariants(modelId, provider.id);
+        for (const variant of variants) {
+          const supported = await Promise.resolve(provider.supportsModel(variant));
+          if (supported) {
+            found = provider.id;
+            foundModelId = variant;
+            break;
+          }
+        }
+        if (found) {
           break;
         }
       }
-      if (found) {
-        break;
+      if (!found) {
+        throw new Error(
+          `benchmark_model: model '${modelId}' was not found in any registered provider`,
+        );
       }
+      providerId = found;
+      executableModelId = foundModelId ?? modelId;
     }
-    if (!found) {
-      throw new Error(
-        `benchmark_model: model '${modelId}' was not found in any registered provider`,
-      );
-    }
-    providerId = found;
-    executableModelId = foundModelId ?? modelId;
   }
 
   const provider = registry.get(providerId);

--- a/test/modules/benchmark/model-benchmarker.test.ts
+++ b/test/modules/benchmark/model-benchmarker.test.ts
@@ -231,6 +231,33 @@ describe('benchmarkModel', () => {
     expect(result.providerId).toBe('test-provider');
   });
 
+  it('uses requested providerId instead of registry lookup when specified', async () => {
+    // Registry says provider is 'test-provider' but caller requests 'lm_studio'
+    const lmStudioProvider = { ...fakeProvider, id: 'lm_studio' };
+    providerRegistryMock.get.mockImplementation((id: string) =>
+      id === 'lm_studio' ? lmStudioProvider : undefined
+    );
+
+    const result = await benchmarkModel({
+      modelId: 'gemma3-4b-64k:latest',
+      providerId: 'lm_studio',
+      taskCategories: ['chat'],
+    });
+
+    expect(result.providerId).toBe('lm_studio');
+    // modelRegistry.getModel should still be called (for contextWindow), but
+    // provider selection must not be overridden by registry providerId
+    expect(providerRegistryMock.get).toHaveBeenCalledWith('lm_studio');
+  });
+
+  it('throws when requested providerId is not in registry', async () => {
+    providerRegistryMock.get.mockReturnValue(undefined);
+
+    await expect(
+      benchmarkModel({ modelId: 'gemma3-4b-64k:latest', providerId: 'unknown_provider', taskCategories: ['chat'] })
+    ).rejects.toThrow(/not in the registry/);
+  });
+
   it('resolves provider-prefixed model ids when requested id is unprefixed', async () => {
     modelRegistryMock.getModel.mockReturnValue(undefined);
 


### PR DESCRIPTION
## Summary

Fixes #87.

`benchmark_model` was ignoring the caller's `provider_id` when the same model id exists on multiple local providers. The model registry lookup or first-provider scan silently overwrote the requested provider, causing misattributed benchmark records (e.g. requesting `lm_studio` but getting `providerId: "ollama"` in the response).

- `BenchmarkModelParams.providerId` added — when set, provider resolution bypasses the registry lookup and pins execution to the requested provider
- Requested provider is validated against the registry before proceeding (throws `not in the registry` if unknown)
- `provider_id` arg wired through the MCP tool handler in `src/index.ts`
- `provider_id` field added to the `benchmark_model` tool schema with description clarifying cross-provider collision behavior
- 2 new unit tests: pinned provider wins over registry, unknown provider throws

## Test plan

- [ ] `npm test` passes (369 tests, 0 failures)
- [ ] Call `benchmark_model` with `provider_id: "lm_studio"` and a model that also exists on Ollama — response `providerId` matches `"lm_studio"`
- [ ] Call with unknown `provider_id` — returns error containing `"not in the registry"`
- [ ] Omitting `provider_id` behaves identically to before (registry lookup / scan fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)