### PR TITLE
Fix local route_task queue admission race (fixes #86)

### DIFF
--- a/docs/OPERATIONAL_TEST_PLAN.md
+++ b/docs/OPERATIONAL_TEST_PLAN.md
@@ -342,7 +342,9 @@ No test verifies server behavior under concurrent tool calls:
 
 2026-05-20 update: Unit coverage now defines the expected behavior for the provider execution layer: local providers share one FIFO slot, and one local job can run concurrently with one remote provider job. Remaining work is operational coverage through the live MCP `route_task` path.
 
-**Blocker:** Live concurrency coverage still needs a deterministic harness that can submit simultaneous `route_task` calls and observe completion ordering without making routine test runs slow or paid by default.
+2026-05-22 update: `test-operational.mjs --suite routing` now includes an opt-in live check (`route_task — concurrent local queue admission (Issue #86 live check)`) gated behind `RUN_ROUTE_TASK_CONCURRENCY_TEST=true`. This keeps default routing runs lightweight while providing a deterministic concurrency probe when local runtime access is available.
+
+**Blocker:** Full always-on live concurrency coverage is still gated to avoid slowing default runs and requiring local inference availability in every environment.
 
 ---
 

--- a/src/modules/api-integration/routing/index.ts
+++ b/src/modules/api-integration/routing/index.ts
@@ -39,6 +39,41 @@ import type { JobStatus as PersistedJobStatus, TaskStatus as PersistedTaskStatus
 let jobTracker: Awaited<ReturnType<typeof getJobTracker>>;
 
 export class Router implements IRouter {
+  private readonly maxConcurrentLocalQueuedRoutes =
+    Number.isFinite(config.providerMaxConcurrentLocal) && config.providerMaxConcurrentLocal > 0
+      ? Math.floor(config.providerMaxConcurrentLocal)
+      : 1;
+  private activeLocalQueuedRoutes = 0;
+  private localQueuedRouteWaiters: Array<() => void> = [];
+
+  private pumpLocalQueuedRoutes(): void {
+    while (
+      this.activeLocalQueuedRoutes < this.maxConcurrentLocalQueuedRoutes &&
+      this.localQueuedRouteWaiters.length > 0
+    ) {
+      const next = this.localQueuedRouteWaiters.shift();
+      if (!next) break;
+      this.activeLocalQueuedRoutes += 1;
+      next();
+    }
+  }
+
+  private async acquireQueuedRouteExecutionSlot(providerId: string): Promise<() => void> {
+    if (!isProviderLocal(providerId)) {
+      return () => {};
+    }
+
+    await new Promise<void>((resolve) => {
+      this.localQueuedRouteWaiters.push(resolve);
+      this.pumpLocalQueuedRoutes();
+    });
+
+    return () => {
+      this.activeLocalQueuedRoutes = Math.max(0, this.activeLocalQueuedRoutes - 1);
+      this.pumpLocalQueuedRoutes();
+    };
+  }
+
   private providerLooksUnavailable(providerId: string): boolean {
     const registry = getProviderRegistry();
     return !registry.has(providerId) || !registry.isAvailable(providerId);
@@ -203,9 +238,17 @@ export class Router implements IRouter {
     });
   }
 
-  private async runQueuedRouteTask(taskId: string, params: RouteTaskParams): Promise<void> {
+  private async runQueuedRouteTask(taskId: string, providerId: string, params: RouteTaskParams): Promise<void> {
     const tracker = await getJobTracker();
+    const releaseSlot = await this.acquireQueuedRouteExecutionSlot(providerId);
     try {
+      const jobsForTask = await getJobsByTaskId(taskId);
+      const persistedTopLevelJob = jobsForTask.find((job) => job.id === taskId);
+      if (persistedTopLevelJob?.status === 'cancelled') {
+        await this.updateTaskFromJobs(taskId);
+        return;
+      }
+
       await updateJob({ id: taskId, status: 'in_progress', progress_pct: 1, started_at: Date.now(), poll_again_after_ms: 15_000 });
       await updateTask({ id: taskId, status: 'in_progress' });
       const result = await this.executeRouteTaskBlocking(params, taskId);
@@ -216,6 +259,7 @@ export class Router implements IRouter {
       await tracker.failJob(taskId, message);
       await updateTask({ id: taskId, status: 'failed', completed_count: 0, failed_count: 1 });
     } finally {
+      releaseSlot();
       await refreshAlertState();
     }
   }
@@ -322,7 +366,7 @@ export class Router implements IRouter {
       poll_again_after_ms: 5_000,
     });
 
-    void this.runQueuedRouteTask(taskId, params);
+    void this.runQueuedRouteTask(taskId, providerId, params);
 
     return {
       task_id: taskId,

--- a/src/modules/api-integration/task-execution/index.ts
+++ b/src/modules/api-integration/task-execution/index.ts
@@ -38,6 +38,16 @@ function resolveModelId(modelId: string): { providerId: string | null; bareId: s
  *     no prefix and no registry entry — backward-compat with old callers).
  */
 export class TaskExecutor implements ITaskExecutor {
+  private async updateProgressSafely(jobId: string, progress: number, estimatedMs: number): Promise<void> {
+    try {
+      await jobTracker.updateJobProgress(jobId, progress, estimatedMs);
+    } catch (err) {
+      logger.error(
+        `Failed to update job progress (${progress}%) for job ${jobId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
   async executeTask(modelId: string, task: string, jobId: string): Promise<string> {
     logger.info(`Executing task with model ${modelId} for job ${jobId}`);
 
@@ -48,15 +58,9 @@ export class TaskExecutor implements ITaskExecutor {
       throw err;
     }
 
-    try {
-      void jobTracker.updateJobProgress(jobId, 25, 120_000);
-    } catch (err) {
-      logger.error(`Failed to update job progress (25%) for job ${jobId}: ${err instanceof Error ? err.message : String(err)}`);
-    }
-
     let result: string;
     try {
-      result = await this._dispatch(modelId, task);
+      result = await this._dispatch(modelId, task, jobId);
     } catch (error) {
       logger.error(`Error executing task for job ${jobId}:`, error);
       try {
@@ -70,11 +74,7 @@ export class TaskExecutor implements ITaskExecutor {
       throw error;
     }
 
-    try {
-      void jobTracker.updateJobProgress(jobId, 75, 30_000);
-    } catch (err) {
-      logger.error(`Failed to update job progress (75%) for job ${jobId}: ${err instanceof Error ? err.message : String(err)}`);
-    }
+    await this.updateProgressSafely(jobId, 75, 30_000);
 
     logger.info(`Job ${jobId} completed successfully`);
     return result;
@@ -86,6 +86,7 @@ export class TaskExecutor implements ITaskExecutor {
     task: string,
     options: TaskExecutionOptions,
     source: string,
+    jobId: string,
   ): Promise<string> {
     const registry = getProviderRegistry();
     const provider = registry.get(providerId);
@@ -99,10 +100,10 @@ export class TaskExecutor implements ITaskExecutor {
 
     try {
       const executionOptions = { ...buildCodeTaskExecutionOptions(task, provider.id), ...options };
-      const result = await registry.executeWithConcurrencyLimit(
-        provider,
-        async () => await provider.executeTask(bareId, task, executionOptions),
-      );
+      const result = await registry.executeWithConcurrencyLimit(provider, async () => {
+        await this.updateProgressSafely(jobId, 25, 120_000);
+        return await provider.executeTask(bareId, task, executionOptions);
+      });
       registry.recordProviderSuccess(provider.id);
       return result.content;
     } catch (error) {
@@ -112,7 +113,7 @@ export class TaskExecutor implements ITaskExecutor {
   }
 
   /** Dispatch to the right provider without job tracking (pure routing). */
-  private async _dispatch(modelId: string, task: string): Promise<string> {
+  private async _dispatch(modelId: string, task: string, jobId: string): Promise<string> {
     const { providerId: prefixProviderId, bareId } = resolveModelId(modelId);
     const registry = getProviderRegistry();
     const modelRegistry = getModelRegistry();
@@ -134,7 +135,7 @@ export class TaskExecutor implements ITaskExecutor {
       if (registry.get(meta.providerId)) {
         logger.debug(`Dispatching ${bareId} via registry (provider: ${meta.providerId})`);
         try {
-          return await this.executeWithProvider(meta.providerId, bareId, task, options, 'registry lookup');
+          return await this.executeWithProvider(meta.providerId, bareId, task, options, 'registry lookup', jobId);
         } catch (error) {
           lastError = error instanceof Error ? error : new Error(String(error));
           logger.warn(`Primary provider dispatch failed for ${bareId} via ${meta.providerId}: ${lastError.message}`);
@@ -147,7 +148,7 @@ export class TaskExecutor implements ITaskExecutor {
       if (registry.get(prefixProviderId)) {
         logger.debug(`Dispatching ${bareId} via prefix (provider: ${prefixProviderId})`);
         try {
-          return await this.executeWithProvider(prefixProviderId, bareId, task, options, 'prefixed model id');
+          return await this.executeWithProvider(prefixProviderId, bareId, task, options, 'prefixed model id', jobId);
         } catch (error) {
           lastError = error instanceof Error ? error : new Error(String(error));
           logger.warn(`Prefix provider dispatch failed for ${bareId} via ${prefixProviderId}: ${lastError.message}`);
@@ -167,7 +168,7 @@ export class TaskExecutor implements ITaskExecutor {
       if (supports) {
         logger.debug(`Dispatching ${bareId} to local provider ${provider.id} (fallback probe)`);
         try {
-          return await this.executeWithProvider(provider.id, bareId, task, options, 'local fallback probe');
+          return await this.executeWithProvider(provider.id, bareId, task, options, 'local fallback probe', jobId);
         } catch (error) {
           lastError = error instanceof Error ? error : new Error(String(error));
           logger.warn(`Local fallback provider ${provider.id} failed for ${bareId}: ${lastError.message}`);
@@ -187,7 +188,7 @@ export class TaskExecutor implements ITaskExecutor {
       if (supports) {
         logger.debug(`Dispatching ${bareId} to provider ${provider.id} (fallback probe)`);
         try {
-          return await this.executeWithProvider(provider.id, bareId, task, options, 'remote fallback probe');
+          return await this.executeWithProvider(provider.id, bareId, task, options, 'remote fallback probe', jobId);
         } catch (error) {
           lastError = error instanceof Error ? error : new Error(String(error));
           logger.warn(`Fallback provider ${provider.id} failed for ${bareId}: ${lastError.message}`);

--- a/test-operational.mjs
+++ b/test-operational.mjs
@@ -10,7 +10,7 @@
  * Suites:
  *   all       (default) Run every test
  *   smoke     Startup, tool list, resource reads only (no LLM calls)
- *   routing   preemptive_route_task + get_cost_estimate (no LLM calls)
+ *   routing   preemptive_route_task + get_cost_estimate (+ optional live route_task concurrency check)
  *   storage   DB persistence, lock contention, data-dir isolation (no LLM calls)
  *   llm       route_task with Ollama (makes real LLM calls, slower)
  */
@@ -480,6 +480,74 @@ async function runSuite(client, serverEnv) {
         const paidCost  = parsed.paid?.cost?.total ?? parsed.estimatedCost ?? '?';
         info(`Cost estimate — local: $${localCost}  paid: $${paidCost}`);
       }
+    });
+
+    await runTest('route_task — concurrent local queue admission (Issue #86 live check)', async () => {
+      const liveConcurrencyEnabled = String(process.env.RUN_ROUTE_TASK_CONCURRENCY_TEST || '').toLowerCase() === 'true';
+      if (!liveConcurrencyEnabled) {
+        info('Skipping live route_task concurrency check (set RUN_ROUTE_TASK_CONCURRENCY_TEST=true to enable)');
+        results.skipped++;
+        return;
+      }
+
+      const makeArgs = (index) => ({
+        task: `Write a tiny helper function #${index} and return only code.`,
+        context_length: 40,
+        expected_output_length: 120,
+        complexity: 0.2,
+        priority: 'cost',
+      });
+
+      const responses = await Promise.all([
+        client.callTool({ name: 'route_task', arguments: makeArgs(1) }),
+        client.callTool({ name: 'route_task', arguments: makeArgs(2) }),
+        client.callTool({ name: 'route_task', arguments: makeArgs(3) }),
+      ]);
+
+      const parsedResponses = responses.map((response) => {
+        const text = extractText(response);
+        return text ? JSON.parse(text) : null;
+      });
+
+      assert(parsedResponses.every((entry) => !!entry?.task_id), 'Concurrent route_task calls return task IDs');
+      assert(parsedResponses.every((entry) => entry?.status === 'queued'), 'Concurrent route_task calls initially return queued status');
+
+      const localProviderIds = new Set(['local', 'ollama', 'lm-studio', 'llama-cpp']);
+      const allLocal = parsedResponses.every((entry) => localProviderIds.has(String(entry?.provider)));
+      if (!allLocal) {
+        info('Skipping local queue assertion because at least one call routed to a non-local provider');
+        results.skipped++;
+        return;
+      }
+
+      const taskIds = parsedResponses.map((entry) => entry.task_id);
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      const statuses = await Promise.all(
+        taskIds.map(async (taskId) => {
+          const statusResult = await client.callTool({
+            name: 'get_task_status',
+            arguments: { task_id: taskId },
+          });
+          return JSON.parse(extractText(statusResult));
+        }),
+      );
+
+      const inProgressCount = statuses.filter((status) => status.status === 'in_progress').length;
+      const queuedCount = statuses.filter((status) => status.status === 'queued').length;
+      const localCap = Math.max(1, Number.parseInt(String(process.env.PROVIDER_MAX_CONCURRENT_LOCAL || '1'), 10) || 1);
+
+      assert(inProgressCount <= localCap, `In-progress local tasks (${inProgressCount}) do not exceed local cap (${localCap})`);
+      assert(queuedCount >= Math.max(0, taskIds.length - localCap), 'Later tasks remain queued while local slots are occupied');
+
+      await Promise.all(
+        taskIds.map(async (taskId) => {
+          await client.callTool({
+            name: 'cancel_task',
+            arguments: { task_id: taskId },
+          });
+        }),
+      );
     });
 
     await runTest('route_task — oversized prompt returns context_overflow', async () => {

--- a/test/modules/api-integration/routing/index.test.ts
+++ b/test/modules/api-integration/routing/index.test.ts
@@ -14,6 +14,7 @@ jest.unstable_mockModule('../../../../dist/config/index.js', () => ({
     openRouterApiKey: 'test-key',
     openRouterFreeOnly: false,
     costThreshold: 0.02,
+    providerMaxConcurrentLocal: 1,
   },
 }));
 
@@ -199,6 +200,88 @@ describe('api-integration routing', () => {
       job_count: 1,
     }));
     expect(mockCreateJob).toHaveBeenCalledWith(result.task_id, expect.stringContaining('implementation plan'), 'openai/gpt-4o');
+  });
+
+  it('keeps later local queued tasks out of in_progress until a local slot is available', async () => {
+    mockRouteTaskDecision.mockResolvedValueOnce({
+      provider: 'local',
+      model: 'qwen2.5-coder:7b',
+      explanation: 'Local route for queue serialization test.',
+    });
+    mockRouteTaskDecision.mockResolvedValueOnce({
+      provider: 'local',
+      model: 'qwen2.5-coder:7b',
+      explanation: 'Local route for queue serialization test.',
+    });
+    mockOpenRouterProvider.supportsModel.mockResolvedValue(false);
+
+    let releaseFirstExecution: (() => void) | undefined;
+    const executeMock = jest
+      .fn()
+      .mockImplementationOnce(async () => {
+        await new Promise<void>((resolve) => {
+          releaseFirstExecution = resolve;
+        });
+        return {
+          model: 'qwen2.5-coder:7b',
+          providerId: 'local',
+          costClass: 'local',
+          provider: 'local',
+          reason: 'first',
+          resultCode: 'first-result',
+          estimatedCost: 0,
+        };
+      })
+      .mockResolvedValue({
+        model: 'qwen2.5-coder:7b',
+        providerId: 'local',
+        costClass: 'local',
+        provider: 'local',
+        reason: 'second',
+        resultCode: 'second-result',
+        estimatedCost: 0,
+      });
+
+    const internalRouter = router as unknown as { executeRouteTaskBlocking: typeof executeMock };
+    const originalExecute = internalRouter.executeRouteTaskBlocking;
+    internalRouter.executeRouteTaskBlocking = executeMock;
+
+    try {
+      await Promise.all([
+        routeTask({
+          task: 'First queued local task',
+          contextLength: 64,
+          expectedOutputLength: 128,
+          complexity: 0.5,
+          priority: 'cost',
+        }),
+        routeTask({
+          task: 'Second queued local task',
+          contextLength: 64,
+          expectedOutputLength: 128,
+          complexity: 0.5,
+          priority: 'cost',
+        }),
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const inProgressBeforeRelease = mockUpdateJob.mock.calls.filter(
+        ([job]) => job?.status === 'in_progress',
+      ).length;
+      expect(inProgressBeforeRelease).toBe(1);
+
+      releaseFirstExecution?.();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const inProgressAfterRelease = mockUpdateJob.mock.calls.filter(
+        ([job]) => job?.status === 'in_progress',
+      ).length;
+      expect(inProgressAfterRelease).toBe(2);
+    } finally {
+      mockOpenRouterProvider.supportsModel.mockResolvedValue(true);
+      internalRouter.executeRouteTaskBlocking = originalExecute;
+    }
   });
 
   it('get_task_status returns aggregate task status and inline completed results', async () => {


### PR DESCRIPTION
## Summary
- keep queued route_task jobs in queued state until a local execution slot is actually granted
- honor PROVIDER_MAX_CONCURRENT_LOCAL for queued local route admission using FIFO slot gating
- move 25% job progress update to provider-slot execution start so started_at reflects real start time
- add regression coverage for queued local admission and an opt-in live routing concurrency check in test-operational.mjs --suite routing

## Validation
- npm run lint
- npm test

Fixes #86