### PR TITLE
Fix local provider single-slot concurrency cap broken (#86)

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -20,3 +20,25 @@ Create a GitHub issue.
 ## When a skill says "fetch the relevant ticket"
 
 Run `gh issue view <number> --comments`.
+
+## Current recommended work order (2026-05-22)
+
+Prioritize by production impact first (correctness/concurrency), then contention/visibility, then llama-cpp feature work with explicit dependencies.
+
+| Order | Issue | Why this order |
+| --- | --- | --- |
+| 1 | [#86](https://github.com/Heratiki/locallama-mcp/issues/86) | [COMPLETE] Core P1 correctness bug: local single-slot FIFO is broken under concurrency; many queue semantics depend on this being fixed first. |
+| 2 | [#83](https://github.com/Heratiki/locallama-mcp/issues/83) | Core P1 correctness bug: stale `get_task_status` breaks polling trust and masks real queue behavior. |
+| 3 | [#88](https://github.com/Heratiki/locallama-mcp/issues/88) | Queue position reporting bug; safest to fix after #86/#83 so position and status are based on corrected queue lifecycle. |
+| 4 | [#97](https://github.com/Heratiki/locallama-mcp/issues/97) | High-impact contention reduction: disables startup benchmark sweeps and moves to lazy benchmark freshness model. |
+| 5 | [#84](https://github.com/Heratiki/locallama-mcp/issues/84) | Complements #97 by adding queue/priority semantics and contention signaling when benchmarks block task work. |
+| 6 | [#85](https://github.com/Heratiki/locallama-mcp/issues/85) | Observability layer (`get_system_state`) is most useful after status/queue/benchmark behavior above is corrected. |
+| 7 | [#94](https://github.com/Heratiki/locallama-mcp/issues/94) | llama-cpp prerequisite: binary discovery is explicitly required by #92 and #95. |
+| 8 | [#92](https://github.com/Heratiki/locallama-mcp/issues/92) | llama-cpp process ownership baseline; needed before metadata-aware spawn behavior in #93. |
+| 9 | [#93](https://github.com/Heratiki/locallama-mcp/issues/93) | Depends on spawn flow from #92; adds GGUF-driven flag correctness for reliable inference behavior. |
+| 10 | [#95](https://github.com/Heratiki/locallama-mcp/issues/95) | Depends on #94 and #93 (and references #91); best delivered once llama-cpp discovery + metadata are in place. |
+
+### Dependency notes
+
+- Explicit issue dependencies from descriptions: `#94 -> (#92, #95)`, `#92 -> #93`, `#93 -> #95`.
+- Related sequencing constraints: `#86/#83` before `#88`; `#97` before full contention/visibility polishing in `#84/#85`.

--- a/src/modules/api-integration/routing/index.ts
+++ b/src/modules/api-integration/routing/index.ts
@@ -39,14 +39,16 @@ import type { JobStatus as PersistedJobStatus, TaskStatus as PersistedTaskStatus
 let jobTracker: Awaited<ReturnType<typeof getJobTracker>>;
 
 export class Router implements IRouter {
-  private readonly maxConcurrentLocalQueuedRoutes =
-    Number.isFinite(config.providerMaxConcurrentLocal) && config.providerMaxConcurrentLocal > 0
+  private get maxConcurrentLocalQueuedRoutes(): number {
+    return Number.isFinite(config.providerMaxConcurrentLocal) && config.providerMaxConcurrentLocal > 0
       ? Math.floor(config.providerMaxConcurrentLocal)
       : 1;
+  }
   private activeLocalQueuedRoutes = 0;
   private localQueuedRouteWaiters: Array<() => void> = [];
 
   private pumpLocalQueuedRoutes(): void {
+    logger.debug(`[Router] Pumping local queued routes. Active: ${this.activeLocalQueuedRoutes}/${this.maxConcurrentLocalQueuedRoutes}, Waiters: ${this.localQueuedRouteWaiters.length}`);
     while (
       this.activeLocalQueuedRoutes < this.maxConcurrentLocalQueuedRoutes &&
       this.localQueuedRouteWaiters.length > 0
@@ -54,22 +56,28 @@ export class Router implements IRouter {
       const next = this.localQueuedRouteWaiters.shift();
       if (!next) break;
       this.activeLocalQueuedRoutes += 1;
+      logger.debug(`[Router] Dispatched waiter. Active: ${this.activeLocalQueuedRoutes}/${this.maxConcurrentLocalQueuedRoutes}`);
       next();
     }
   }
 
   private async acquireQueuedRouteExecutionSlot(providerId: string): Promise<() => void> {
-    if (!isProviderLocal(providerId)) {
+    const isLocal = isProviderLocal(providerId);
+    logger.debug(`[Router] acquireQueuedRouteExecutionSlot for provider: ${providerId}, isLocal: ${isLocal}`);
+    
+    if (!isLocal) {
       return () => {};
     }
 
     await new Promise<void>((resolve) => {
       this.localQueuedRouteWaiters.push(resolve);
+      logger.debug(`[Router] Added waiter for local slot. Current waiters: ${this.localQueuedRouteWaiters.length}, active: ${this.activeLocalQueuedRoutes}/${this.maxConcurrentLocalQueuedRoutes}`);
       this.pumpLocalQueuedRoutes();
     });
 
     return () => {
       this.activeLocalQueuedRoutes = Math.max(0, this.activeLocalQueuedRoutes - 1);
+      logger.debug(`[Router] Released local slot. Active: ${this.activeLocalQueuedRoutes}/${this.maxConcurrentLocalQueuedRoutes}`);
       this.pumpLocalQueuedRoutes();
     };
   }

--- a/src/modules/core/provider/rate-limiter.ts
+++ b/src/modules/core/provider/rate-limiter.ts
@@ -1,3 +1,5 @@
+import { config } from '../../../config/index.js';
+
 type ProviderTier = 'local' | 'remote';
 
 interface QueueEntry<T> {
@@ -24,15 +26,8 @@ export interface ProviderRateLimiterOptions {
  */
 export class ProviderRateLimiter {
   private readonly states = new Map<string, ProviderQueueState>();
-  private readonly maxConcurrentLocal: number;
-  private readonly maxConcurrentRemote: number;
 
-  constructor(options: ProviderRateLimiterOptions) {
-    const localCap = Number.isFinite(options.maxConcurrentLocal) ? options.maxConcurrentLocal : 1;
-    const remoteCap = Number.isFinite(options.maxConcurrentRemote) ? options.maxConcurrentRemote : 1;
-    this.maxConcurrentLocal = Math.max(1, Math.floor(localCap));
-    this.maxConcurrentRemote = Math.max(1, Math.floor(remoteCap));
-  }
+  constructor() {}
 
   async schedule<T>(providerId: string, tier: ProviderTier, run: () => Promise<T>): Promise<T> {
     return await new Promise<T>((resolve, reject) => {
@@ -58,7 +53,9 @@ export class ProviderRateLimiter {
   }
 
   private capForTier(tier: ProviderTier): number {
-    return tier === 'local' ? this.maxConcurrentLocal : this.maxConcurrentRemote;
+    const rawCap = tier === 'local' ? config.providerMaxConcurrentLocal : config.providerMaxConcurrentRemote;
+    const cap = Number.isFinite(rawCap) ? rawCap : 1;
+    return Math.max(1, Math.floor(cap));
   }
 
   private drain(queueKey: string, tier: ProviderTier): void {

--- a/src/modules/core/provider/registry.ts
+++ b/src/modules/core/provider/registry.ts
@@ -24,10 +24,7 @@ export class ProviderRegistry {
   // --- Health probe (Issue 26) ---
   private healthProbeTimer: ReturnType<typeof setInterval> | undefined;
   private availabilityMap = new Map<string, boolean>();
-  private readonly rateLimiter = new ProviderRateLimiter({
-    maxConcurrentLocal: config.providerMaxConcurrentLocal,
-    maxConcurrentRemote: config.providerMaxConcurrentRemote,
-  });
+  private readonly rateLimiter = new ProviderRateLimiter();
 
   register(provider: LLMProvider): void {
     if (this.providers.has(provider.id)) {

--- a/src/modules/decision-engine/services/codeTaskCoordinator.ts
+++ b/src/modules/decision-engine/services/codeTaskCoordinator.ts
@@ -310,13 +310,15 @@ ${result}
    * @param model The model to use
    * @param fullContext Optional additional context for the model
    * @param originalTask Optional original task description for context
+   * @param jobTracker Optional job tracker for progress updates
    * @returns The model's response
    */
   async executeSubtask(
     subtask: CodeSubtask,
     model: Model,
     fullContext?: string,
-    originalTask?: string // Add originalTask parameter
+    originalTask?: string, // Add originalTask parameter
+    jobTracker?: JobTracker | null // Add jobTracker parameter
   ): Promise<string> {
     // Enhanced logging: Log detailed subtask information
     logger.info(`------- SUBTASK EXECUTION START -------`);
@@ -386,7 +388,17 @@ Output only the code required for this subtask. Do not include explanations unle
         logger.info(`Executing subtask ${subtask.id} with ${provider.displayName} model: ${bareId}`);
         const execResult = await registry.executeWithConcurrencyLimit(
           provider,
-          async () => await provider.executeTask(bareId, prompt, { timeoutMs: timeout }),
+          async () => {
+            // Update job status to In Progress ONLY AFTER acquiring the slot
+            if (jobTracker) {
+              try {
+                await jobTracker.updateJobProgress(subtask.id, 10);
+              } catch (error) {
+                logger.warn(`Failed to update job progress for subtask ${subtask.id}:`, error);
+              }
+            }
+            return await provider.executeTask(bareId, prompt, { timeoutMs: timeout });
+          },
         );
         resultText = execResult.content;
         logger.info(`Successfully executed subtask ${subtask.id} with ${provider.displayName} model: ${bareId}`);
@@ -401,7 +413,17 @@ Output only the code required for this subtask. Do not include explanations unle
             logger.info(`Falling back to provider '${p.id}' for model ${bareId}`);
             const execResult = await registry.executeWithConcurrencyLimit(
               p,
-              async () => await p.executeTask(bareId, prompt, { timeoutMs: timeout }),
+              async () => {
+                // Update job status to In Progress ONLY AFTER acquiring the slot
+                if (jobTracker) {
+                  try {
+                    await jobTracker.updateJobProgress(subtask.id, 10);
+                  } catch (error) {
+                    logger.warn(`Failed to update job progress for subtask ${subtask.id}:`, error);
+                  }
+                }
+                return await p.executeTask(bareId, prompt, { timeoutMs: timeout });
+              },
             );
             resultText = execResult.content;
             found = true;
@@ -539,18 +561,6 @@ Output only the code required for this subtask. Do not include explanations unle
       completedCount++;
       logger.info(`Executing subtask ${completedCount}/${executionOrder.length}: ${subtask.id}`);
       
-      // Update job status to In Progress (if job tracker is available)
-      // Check if jobTracker is not null before using it
-      if (jobTracker) {
-        try {
-          await jobTracker.updateJobProgress(subtask.id, 10); // Start at 10%
-        } catch (error) {
-          logger.warn(`Failed to update job progress for subtask ${subtask.id}:`, error);
-        }
-      } else {
-         logger.debug(`JobTracker not available, skipping progress update (10%) for subtask ${subtask.id}`);
-      }
-      
       // Gather context from dependencies
       let dependencyContext = '';
       for (const depId of subtask.dependencies) {
@@ -581,15 +591,12 @@ Output only the code required for this subtask. Do not include explanations unle
         } catch (error) {
           logger.warn(`Failed to update job progress for subtask ${subtask.id}:`, error);
         }
-      } else {
-         logger.debug(`JobTracker not available, skipping progress update (30%) for subtask ${subtask.id}`);
       }
-      
+
       try {
         // Execute the subtask
-        const result = await this.executeSubtask(subtask, model, dependencyContext, decomposedTask.originalTask); // Pass originalTask
+        const result = await this.executeSubtask(subtask, model, dependencyContext, decomposedTask.originalTask, jobTracker); // Pass originalTask and jobTracker
         results.set(subtask.id, result);
-        
         // Write the result to the subtask log file
         this.logSubtaskResult(subtask, model, result);
         


### PR DESCRIPTION
This PR fixes issue #86 where concurrent route_task submissions could bypass the local single-slot FIFO queue.

### Changes:
- **Dynamic Limits:** Updated Router and ProviderRateLimiter to read concurrency caps directly from the configuration, respecting hot-reloads.
- **Accurate Timestamps:** Moved database status transitions and started_at timestamp setting inside the execution lock for subtasks.
- **Improved Logging:** Added debug logging to the Router's queue management.

Verification with a reproduction script confirmed that local execution is now strictly serialized and database timestamps no longer overlap for concurrent submissions.