### PR TITLE
Fix #84: deprioritize benchmark queue and expose local contention signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,24 @@ Example usage:
 }
 ```
 
+When local providers are under benchmark load, `route_task` may include optional contention metadata:
+
+```json
+{
+  "task_id": "...",
+  "status": "queued",
+  "queue_position": 2,
+  "benchmark_contention": {
+    "local_slot_contended": true,
+    "active_benchmark_runs": 1,
+    "queued_benchmark_runs": 2,
+    "message": "Local execution slot currently contended by benchmark workloads. Task remains queued until local slot is free."
+  }
+}
+```
+
+This field is omitted when no benchmark workload is occupying the local execution queue.
+
 ### "Retriv First" Strategy
 
 The server now implements a "Retriv First" strategy to prioritize existing code:

--- a/src/modules/api-integration/routing/index.ts
+++ b/src/modules/api-integration/routing/index.ts
@@ -375,6 +375,17 @@ export class Router implements IRouter {
 
     // Compute position at read time after insert so concurrent submissions get distinct values.
     const queuePosition = (await getQueuePositionForJob(taskId)) ?? 1;
+    const localQueueStats = isProviderLocal(providerId)
+      ? getProviderRegistry().getLocalExecutionQueueStats()
+      : null;
+    const benchmarkContention = localQueueStats && (localQueueStats.activeBenchmarks > 0 || localQueueStats.queuedBenchmarks > 0)
+      ? {
+          local_slot_contended: true,
+          active_benchmark_runs: localQueueStats.activeBenchmarks,
+          queued_benchmark_runs: localQueueStats.queuedBenchmarks,
+          message: 'Local execution slot currently contended by benchmark workloads. Task remains queued until local slot is free.',
+        }
+      : undefined;
 
     void this.runQueuedRouteTask(taskId, providerId, params);
 
@@ -386,6 +397,7 @@ export class Router implements IRouter {
       poll_again_after_ms: 5_000,
       provider: providerId,
       model: decision.model,
+      benchmark_contention: benchmarkContention,
     };
   }
 

--- a/src/modules/api-integration/routing/types.ts
+++ b/src/modules/api-integration/routing/types.ts
@@ -53,6 +53,12 @@ export interface QueuedRouteTaskResult {
   poll_again_after_ms: number;
   provider: string;
   model: string;
+  benchmark_contention?: {
+    local_slot_contended: boolean;
+    active_benchmark_runs: number;
+    queued_benchmark_runs: number;
+    message: string;
+  };
 }
 
 export interface TaskStatusJobSummary {

--- a/src/modules/api-integration/task-execution/index.ts
+++ b/src/modules/api-integration/task-execution/index.ts
@@ -104,7 +104,7 @@ export class TaskExecutor implements ITaskExecutor {
       const result = await registry.executeWithConcurrencyLimit(provider, async () => {
         await this.updateProgressSafely(jobId, 25, 120_000, provider.id);
         return await provider.executeTask(bareId, task, executionOptions);
-      });
+      }, { workload: 'task' });
       registry.recordProviderSuccess(provider.id);
       return result.content;
     } catch (error) {

--- a/src/modules/benchmark/core/model-benchmarker.ts
+++ b/src/modules/benchmark/core/model-benchmarker.ts
@@ -279,7 +279,11 @@ export async function benchmarkModel(
       const startMs = Date.now();
 
       try {
-        const execResult = await provider.executeTask(executableModelId, benchTask.task, { timeoutMs });
+        const execResult = await registry.executeWithConcurrencyLimit(
+          provider,
+          async () => await provider.executeTask(executableModelId, benchTask.task, { timeoutMs }),
+          { workload: 'benchmark', priority: 'background' },
+        );
         const elapsed = Date.now() - startMs;
         const quality = evaluateQuality(benchTask.task, execResult.content);
 

--- a/src/modules/benchmark/core/runner.ts
+++ b/src/modules/benchmark/core/runner.ts
@@ -141,11 +141,16 @@ export async function runModelBenchmark(
       let completionTokens = 0;
       let runOutput = '';
 
-      const registryProvider = getProviderRegistry().get(model.provider);
+      const providerRegistry = getProviderRegistry();
+      const registryProvider = providerRegistry.get(model.provider);
       if (registryProvider) {
         try {
           const execResult = await withHardTimeout(
-            registryProvider.executeTask(model.id, task, { timeoutMs: effectiveTimeout }),
+            providerRegistry.executeWithConcurrencyLimit(
+              registryProvider,
+              async () => await registryProvider.executeTask(model.id, task, { timeoutMs: effectiveTimeout }),
+              { workload: 'benchmark', priority: 'background' },
+            ),
             effectiveTimeout,
             `Benchmark run timed out after ${effectiveTimeout}ms for model ${model.id}`
           );

--- a/src/modules/core/provider/rate-limiter.ts
+++ b/src/modules/core/provider/rate-limiter.ts
@@ -1,16 +1,33 @@
 import { config } from '../../../config/index.js';
 
 type ProviderTier = 'local' | 'remote';
+type WorkloadKind = 'task' | 'benchmark';
+type QueuePriority = 'normal' | 'background';
+
+export interface ProviderScheduleOptions {
+  workload?: WorkloadKind;
+  priority?: QueuePriority;
+}
 
 interface QueueEntry<T> {
   run: () => Promise<T>;
   resolve: (value: T) => void;
   reject: (reason?: unknown) => void;
+  workload: WorkloadKind;
+  priority: QueuePriority;
 }
 
 interface ProviderQueueState {
   activeCount: number;
+  activeBenchmarks: number;
   queue: Array<QueueEntry<unknown>>;
+}
+
+export interface ProviderQueueStats {
+  activeCount: number;
+  queuedCount: number;
+  activeBenchmarks: number;
+  queuedBenchmarks: number;
 }
 
 export interface ProviderRateLimiterOptions {
@@ -26,17 +43,50 @@ export interface ProviderRateLimiterOptions {
  */
 export class ProviderRateLimiter {
   private readonly states = new Map<string, ProviderQueueState>();
+  private readonly options: ProviderRateLimiterOptions;
 
-  constructor() {}
+  constructor(options?: Partial<ProviderRateLimiterOptions>) {
+    this.options = {
+      maxConcurrentLocal: options?.maxConcurrentLocal ?? config.providerMaxConcurrentLocal,
+      maxConcurrentRemote: options?.maxConcurrentRemote ?? config.providerMaxConcurrentRemote,
+    };
+  }
 
-  async schedule<T>(providerId: string, tier: ProviderTier, run: () => Promise<T>): Promise<T> {
+  async schedule<T>(providerId: string, tier: ProviderTier, run: () => Promise<T>, options?: ProviderScheduleOptions): Promise<T> {
     return await new Promise<T>((resolve, reject) => {
       const queueKey = this.queueKeyFor(providerId, tier);
       const state = this.getOrCreateState(queueKey);
-      const entry: QueueEntry<T> = { run, resolve, reject };
-      state.queue.push(entry as QueueEntry<unknown>);
+      const entry: QueueEntry<T> = {
+        run,
+        resolve,
+        reject,
+        workload: options?.workload ?? 'task',
+        priority: options?.priority ?? 'normal',
+      };
+      this.enqueue(state, entry as QueueEntry<unknown>);
       this.drain(queueKey, tier);
     });
+  }
+
+  getQueueStats(providerId: string, tier: ProviderTier): ProviderQueueStats {
+    const queueKey = this.queueKeyFor(providerId, tier);
+    const state = this.states.get(queueKey);
+    if (!state) {
+      return {
+        activeCount: 0,
+        queuedCount: 0,
+        activeBenchmarks: 0,
+        queuedBenchmarks: 0,
+      };
+    }
+
+    const queuedBenchmarks = state.queue.filter((entry) => entry.workload === 'benchmark').length;
+    return {
+      activeCount: state.activeCount,
+      queuedCount: state.queue.length,
+      activeBenchmarks: state.activeBenchmarks,
+      queuedBenchmarks,
+    };
   }
 
   private queueKeyFor(providerId: string, tier: ProviderTier): string {
@@ -47,13 +97,33 @@ export class ProviderRateLimiter {
     const existing = this.states.get(providerId);
     if (existing) return existing;
 
-    const created: ProviderQueueState = { activeCount: 0, queue: [] };
+    const created: ProviderQueueState = { activeCount: 0, activeBenchmarks: 0, queue: [] };
     this.states.set(providerId, created);
     return created;
   }
 
+  private enqueue(state: ProviderQueueState, entry: QueueEntry<unknown>): void {
+    if (entry.priority === 'background') {
+      state.queue.push(entry);
+      return;
+    }
+
+    if (entry.workload !== 'task') {
+      state.queue.push(entry);
+      return;
+    }
+
+    const firstBenchmarkIdx = state.queue.findIndex((queued) => queued.workload === 'benchmark');
+    if (firstBenchmarkIdx === -1) {
+      state.queue.push(entry);
+      return;
+    }
+
+    state.queue.splice(firstBenchmarkIdx, 0, entry);
+  }
+
   private capForTier(tier: ProviderTier): number {
-    const rawCap = tier === 'local' ? config.providerMaxConcurrentLocal : config.providerMaxConcurrentRemote;
+    const rawCap = tier === 'local' ? this.options.maxConcurrentLocal : this.options.maxConcurrentRemote;
     const cap = Number.isFinite(rawCap) ? rawCap : 1;
     return Math.max(1, Math.floor(cap));
   }
@@ -70,6 +140,9 @@ export class ProviderRateLimiter {
       }
 
       state.activeCount += 1;
+      if (next.workload === 'benchmark') {
+        state.activeBenchmarks += 1;
+      }
       void next
         .run()
         .then((value) => {
@@ -80,6 +153,9 @@ export class ProviderRateLimiter {
         })
         .finally(() => {
           state.activeCount = Math.max(0, state.activeCount - 1);
+          if (next.workload === 'benchmark') {
+            state.activeBenchmarks = Math.max(0, state.activeBenchmarks - 1);
+          }
           this.drain(queueKey, tier);
         });
     }

--- a/src/modules/core/provider/registry.ts
+++ b/src/modules/core/provider/registry.ts
@@ -1,7 +1,7 @@
 import { logger } from '../../../utils/logger.js';
 import { CostClass, LLMProvider } from './types.js';
 import { CircuitBreaker } from './circuit-breaker.js';
-import { ProviderRateLimiter } from './rate-limiter.js';
+import { ProviderQueueStats, ProviderRateLimiter, ProviderScheduleOptions } from './rate-limiter.js';
 import { config } from '../../../config/index.js';
 import fs from 'fs/promises';
 import path from 'path';
@@ -24,7 +24,10 @@ export class ProviderRegistry {
   // --- Health probe (Issue 26) ---
   private healthProbeTimer: ReturnType<typeof setInterval> | undefined;
   private availabilityMap = new Map<string, boolean>();
-  private readonly rateLimiter = new ProviderRateLimiter();
+  private readonly rateLimiter = new ProviderRateLimiter({
+    maxConcurrentLocal: config.providerMaxConcurrentLocal,
+    maxConcurrentRemote: config.providerMaxConcurrentRemote,
+  });
 
   register(provider: LLMProvider): void {
     if (this.providers.has(provider.id)) {
@@ -146,12 +149,34 @@ export class ProviderRegistry {
     this.circuitBreaker.recordFailure(providerId);
   }
 
-  async executeWithConcurrencyLimit<T>(provider: LLMProvider, run: () => Promise<T>): Promise<T> {
+  async executeWithConcurrencyLimit<T>(provider: LLMProvider, run: () => Promise<T>, options?: ProviderScheduleOptions): Promise<T> {
     return await this.rateLimiter.schedule(
       provider.id,
       provider.isLocal ? 'local' : 'remote',
       run,
+      options,
     );
+  }
+
+  getExecutionQueueStats(providerId: string): ProviderQueueStats {
+    const provider = this.providers.get(providerId);
+    if (!provider) {
+      return {
+        activeCount: 0,
+        queuedCount: 0,
+        activeBenchmarks: 0,
+        queuedBenchmarks: 0,
+      };
+    }
+
+    return this.rateLimiter.getQueueStats(
+      provider.id,
+      provider.isLocal ? 'local' : 'remote',
+    );
+  }
+
+  getLocalExecutionQueueStats(): ProviderQueueStats {
+    return this.rateLimiter.getQueueStats('local', 'local');
   }
 
   // ---------------------------------------------------------------------------

--- a/src/modules/decision-engine/services/benchmarkService.ts
+++ b/src/modules/decision-engine/services/benchmarkService.ts
@@ -833,25 +833,35 @@ export const benchmarkService = {
               );
             } else if (isProviderId(model.provider, 'llama-cpp')) {
               logger.info(`Calling llama.cpp provider for model ${model.id}`);
-              const llamaCppProv = getProviderRegistry().get('llama-cpp');
+              const providerRegistry = getProviderRegistry();
+              const llamaCppProv = providerRegistry.get('llama-cpp');
               if (!llamaCppProv) {
                 throw new Error('llama.cpp provider is not registered');
               }
-              const execResult = await llamaCppProv.executeTask(model.id, task.task, {
-                timeoutMs: Math.round(dynamicTimeout),
-              });
+              const execResult = await providerRegistry.executeWithConcurrencyLimit(
+                llamaCppProv,
+                async () => await llamaCppProv.executeTask(model.id, task.task, {
+                  timeoutMs: Math.round(dynamicTimeout),
+                }),
+                { workload: 'benchmark', priority: 'background' },
+              );
               result = { success: true, text: execResult.content };
             } else {
               // Use provider execution path so OpenRouter rate-limit and quarantine gates are enforced.
-              const provider = getProviderRegistry().get('openrouter');
+              const providerRegistry = getProviderRegistry();
+              const provider = providerRegistry.get('openrouter');
               if (!provider) {
                 throw new Error('OpenRouter provider is not registered');
               }
 
               logger.info(`Calling OpenRouter provider for model ${model.id}`);
-              const execResult = await provider.executeTask(model.id, task.task, {
-                timeoutMs: Math.round(dynamicTimeout),
-              });
+              const execResult = await providerRegistry.executeWithConcurrencyLimit(
+                provider,
+                async () => await provider.executeTask(model.id, task.task, {
+                  timeoutMs: Math.round(dynamicTimeout),
+                }),
+                { workload: 'benchmark', priority: 'background' },
+              );
 
               result = {
                 success: true,

--- a/src/modules/decision-engine/services/codeTaskCoordinator.ts
+++ b/src/modules/decision-engine/services/codeTaskCoordinator.ts
@@ -399,6 +399,7 @@ Output only the code required for this subtask. Do not include explanations unle
             }
             return await provider.executeTask(bareId, prompt, { timeoutMs: timeout });
           },
+          { workload: 'task' },
         );
         resultText = execResult.content;
         logger.info(`Successfully executed subtask ${subtask.id} with ${provider.displayName} model: ${bareId}`);
@@ -424,6 +425,7 @@ Output only the code required for this subtask. Do not include explanations unle
                 }
                 return await p.executeTask(bareId, prompt, { timeoutMs: timeout });
               },
+              { workload: 'task' },
             );
             resultText = execResult.content;
             found = true;

--- a/test/modules/api-integration/routing/index.test.ts
+++ b/test/modules/api-integration/routing/index.test.ts
@@ -126,6 +126,12 @@ const mockRegistry = {
   list: jest.fn(() => [mockOpenRouterProvider]),
   has: jest.fn((providerId: string) => providerId === 'openrouter' || providerId === 'ollama' || providerId === 'lm-studio'),
   isAvailable: jest.fn((providerId: string) => providerId !== 'ollama' && providerId !== 'lm-studio'),
+  getLocalExecutionQueueStats: jest.fn(() => ({
+    activeCount: 0,
+    queuedCount: 0,
+    activeBenchmarks: 0,
+    queuedBenchmarks: 0,
+  })),
   listByCostClass: jest.fn((costClass: string) => {
     if (costClass === 'local') {
       return [{ id: 'ollama' }, { id: 'lm-studio' }];
@@ -156,6 +162,12 @@ describe('api-integration routing', () => {
     mockRegistry.list.mockReturnValue([mockOpenRouterProvider]);
     mockRegistry.has.mockImplementation((providerId: string) => providerId === 'openrouter' || providerId === 'ollama' || providerId === 'lm-studio');
     mockRegistry.isAvailable.mockImplementation((providerId: string) => providerId !== 'ollama' && providerId !== 'lm-studio');
+    mockRegistry.getLocalExecutionQueueStats.mockReturnValue({
+      activeCount: 0,
+      queuedCount: 0,
+      activeBenchmarks: 0,
+      queuedBenchmarks: 0,
+    });
     mockRegistry.listByCostClass.mockImplementation((costClass: string) => {
       if (costClass === 'local') {
         return [{ id: 'ollama' }, { id: 'lm-studio' }];
@@ -279,6 +291,38 @@ describe('api-integration routing', () => {
       mockOpenRouterProvider.supportsModel.mockResolvedValue(true);
       internalRouter.executeRouteTaskBlocking = originalExecute;
     }
+  });
+
+  it('returns benchmark contention metadata for queued local route_task when benchmark load is active', async () => {
+    mockRouteTaskDecision.mockResolvedValueOnce({
+      provider: 'local',
+      model: 'qwen2.5-coder:7b',
+      explanation: 'Local route under benchmark load.',
+    });
+    mockOpenRouterProvider.supportsModel.mockResolvedValue(false);
+    mockRegistry.getLocalExecutionQueueStats.mockReturnValueOnce({
+      activeCount: 1,
+      queuedCount: 2,
+      activeBenchmarks: 1,
+      queuedBenchmarks: 1,
+    });
+
+    const result = await routeTask({
+      task: 'Local task under benchmark contention',
+      contextLength: 64,
+      expectedOutputLength: 64,
+      complexity: 0.5,
+      priority: 'cost',
+    });
+
+    expect(result.provider).toBe('local');
+    expect(result.benchmark_contention).toMatchObject({
+      local_slot_contended: true,
+      active_benchmark_runs: 1,
+      queued_benchmark_runs: 1,
+    });
+
+    mockOpenRouterProvider.supportsModel.mockResolvedValue(true);
   });
 
   it('get_task_status returns aggregate task status and inline completed results', async () => {

--- a/test/modules/benchmark/free-models.test.ts
+++ b/test/modules/benchmark/free-models.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const getFreeModelsMock = jest.fn();
 const executeTaskMock = jest.fn();
+const executeWithConcurrencyLimitMock = jest.fn(async (_provider, run: () => Promise<unknown>) => await run());
 const initBenchmarkDbMock = jest.fn();
 const saveBenchmarkResultMock = jest.fn();
 const getRecentModelResultsMock = jest.fn();
@@ -20,7 +21,8 @@ jest.unstable_mockModule('../../../dist/modules/core/provider/index.js', () => (
           id: 'openrouter',
           executeTask: executeTaskMock
         }
-      : undefined)
+      : undefined),
+    executeWithConcurrencyLimit: executeWithConcurrencyLimitMock,
   })),
   isProviderLocal: jest.fn((providerId: string) => providerId === 'ollama' || providerId === 'lm-studio')
 }));
@@ -51,6 +53,7 @@ describe('benchmarkFreeModels', () => {
       promptTokens: 10,
       completionTokens: 20
     });
+    executeWithConcurrencyLimitMock.mockClear();
   });
 
   it('benchmarks free models through the modular runner and stores results in benchmarkDb', async () => {
@@ -85,6 +88,11 @@ describe('benchmarkFreeModels', () => {
       'openrouter/free-code',
       'Write a JavaScript add function.',
       expect.objectContaining({ timeoutMs: expect.any(Number) })
+    );
+    expect(executeWithConcurrencyLimitMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'openrouter' }),
+      expect.any(Function),
+      { workload: 'benchmark', priority: 'background' },
     );
     expect(saveBenchmarkResultMock).toHaveBeenCalledTimes(1);
     expect(saveBenchmarkResultMock).toHaveBeenCalledWith(expect.objectContaining({

--- a/test/modules/benchmark/model-benchmarker.test.ts
+++ b/test/modules/benchmark/model-benchmarker.test.ts
@@ -14,6 +14,7 @@ jest.unstable_mockModule('../../../dist/utils/logger.js', () => ({
 }));
 
 const executeTaskMock = jest.fn();
+const executeWithConcurrencyLimitMock = jest.fn(async (_provider, run: () => Promise<unknown>) => await run());
 const supportsModelMock = jest.fn();
 const initBenchmarkDbMock = jest.fn();
 const saveBenchmarkResultMock = jest.fn();
@@ -57,6 +58,7 @@ const providerRegistryMock = {
   list: jest.fn().mockReturnValue([fakeProvider]),
   listByCostClass: jest.fn().mockReturnValue([fakeProvider]),
   has: jest.fn().mockReturnValue(true),
+  executeWithConcurrencyLimit: executeWithConcurrencyLimitMock,
 };
 
 jest.unstable_mockModule('../../../dist/modules/core/provider/index.js', () => ({
@@ -116,6 +118,7 @@ describe('benchmarkModel', () => {
       promptTokens: 50,
       completionTokens: 100,
     });
+    executeWithConcurrencyLimitMock.mockClear();
     supportsModelMock.mockReturnValue(false);
   });
 
@@ -131,6 +134,11 @@ describe('benchmarkModel', () => {
 
     // 'code' category has 2 tasks
     expect(executeTaskMock).toHaveBeenCalledTimes(2);
+    expect(executeWithConcurrencyLimitMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'test-provider' }),
+      expect.any(Function),
+      { workload: 'benchmark', priority: 'background' },
+    );
     expect(executeTaskMock.mock.calls[0][0]).toBe('qwen2.5-coder-7b');
     expect(typeof executeTaskMock.mock.calls[0][1]).toBe('string');
   });

--- a/test/modules/core/provider/rate-limiter.test.ts
+++ b/test/modules/core/provider/rate-limiter.test.ts
@@ -88,4 +88,52 @@ describe('ProviderRateLimiter', () => {
     expect([local, remote]).toEqual(['ollama', 'openrouter']);
     expect(observedOverlap).toBe(true);
   });
+
+  it('prioritizes task work ahead of queued benchmark work on local tier', async () => {
+    const limiter = new ProviderRateLimiter({
+      maxConcurrentLocal: 1,
+      maxConcurrentRemote: 1,
+    });
+
+    const events: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+
+    const firstTask = limiter.schedule('ollama', 'local', async () => {
+      events.push('task-1:start');
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      events.push('task-1:end');
+      return 'task-1';
+    }, { workload: 'task' });
+
+    const benchmark = limiter.schedule('ollama', 'local', async () => {
+      events.push('benchmark:start');
+      events.push('benchmark:end');
+      return 'benchmark';
+    }, { workload: 'benchmark', priority: 'background' });
+
+    const secondTask = limiter.schedule('ollama', 'local', async () => {
+      events.push('task-2:start');
+      events.push('task-2:end');
+      return 'task-2';
+    }, { workload: 'task' });
+
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(events).toEqual(['task-1:start']);
+
+    releaseFirst?.();
+    const results = await Promise.all([firstTask, benchmark, secondTask]);
+
+    expect(results).toEqual(['task-1', 'benchmark', 'task-2']);
+    expect(events).toEqual([
+      'task-1:start',
+      'task-1:end',
+      'task-2:start',
+      'task-2:end',
+      'benchmark:start',
+      'benchmark:end',
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- route benchmark executions through shared provider limiter as background workload
- prioritize foreground task work ahead of queued benchmark work in local queue
- expose optional route_task  metadata when local benchmark load is active
- add regression tests for queue priority, benchmark scheduling path, and contention response payload

## Validation
- npm run build
- node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config=jest.config.mjs test/modules/core/provider/rate-limiter.test.ts test/modules/benchmark/free-models.test.ts test/modules/benchmark/model-benchmarker.test.ts test/modules/api-integration/routing/index.test.ts

Closes #84