### PR TITLE
feat: add get_system_state MCP tool for remote queue/benchmark visibility (closes #85)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,7 +31,7 @@ Each Provider has its own independent FIFO Job Queue and execution slot. Jobs fo
 _Avoid_: Global queue, shared queue
 
 **Local Inference Slot**:
-The single execution slot shared by all local Providers (Ollama, LM Studio) combined. Because local Providers share VRAM on a single GPU, only one local Job can run at a time regardless of which local Provider hosts it. Remote Providers (OpenRouter, future: OpenAI, Anthropic) each have their own independent slot and are not VRAM-constrained.
+The single execution slot shared by all local Providers (Ollama, LM Studio, llama.cpp) combined. Because local Providers share VRAM on a single GPU, only one local Job can run at a time regardless of which local Provider hosts it. Remote Providers (OpenRouter, future: OpenAI, Anthropic) each have their own independent slot and are not VRAM-constrained.
 _Avoid_: Worker, thread, connection
 
 **Routing Decision**:
@@ -85,6 +85,10 @@ _Avoid_: Per-call spam, transport-level crash guarantees
 **Monitoring reachability state**:
 The reminder's normalized status for monitoring endpoint checks: `reachable`, `unreachable`, or `unknown` when no conclusive probe result exists yet.
 _Avoid_: Boolean-only status, ad-hoc freeform strings
+
+**System State**:
+A snapshot of current runtime health returned by the `get_system_state` MCP tool. Includes a top-level `status` (`"healthy" | "contended" | "degraded"`), a `reasons` array of active condition codes, a `poll_again_after_ms` hint, a `local_slot` block, and a `remote_providers` array. `status` is the worst-case of all active conditions (`degraded > contended > healthy`). Data sources: Local Inference Slot stats from the in-memory rate limiter; `queued_jobs` counts from the persistent job store; provider availability from the circuit breaker. Valid `reasons` codes: `"local_slot_benchmark_contention"`, `"benchmark_queued"`, `"provider_unavailable"`, `"provider_unreachable"`.
+_Avoid_: System status, health check, status endpoint
 
 **Server-local monitoring endpoint**:
 A monitoring URL emitted in MCP metadata that is resolved from the machine running the MCP server, not the machine running the MCP client. Typical examples are `monitoring.websocketUrl` and the optional dashboard URL. In remote environments, callers may need SSH, container, Codespaces, or WSL port forwarding before these URLs are reachable.

--- a/docs/adr/0003-get-system-state-tool-design.md
+++ b/docs/adr/0003-get-system-state-tool-design.md
@@ -1,0 +1,68 @@
+# get_system_state: MCP tool, slot-aware schema, job-store queue counts
+
+Remote MCP callers have no reliable way to determine why a task is delayed. Existing ambient fields (`_queue_alert`, `_server_reminder`, `benchmark_contention` on `QueuedRouteTaskResult`) are attached to other tool responses and require a prior `route_task` call to observe. The WebSocket side channel is server-local and unreachable from remote clients without port forwarding.
+
+`get_system_state` is a zero-argument MCP tool that returns a structured snapshot of runtime health: top-level `status` and `reasons` for fast agent branching, plus raw counts in `local_slot` and `remote_providers` for diagnostic detail.
+
+## Key decisions
+
+### Tool, not MCP resource
+
+Resources add a second URI-based surface to document, test, and keep in sync with the tool schema. MCP clients reach for `call_tool` not `read_resource` in practice. A tool also lets the response carry `poll_again_after_ms` guidance (already established by `route_task` and `get_task_status`), which a URI resource cannot. The existing `locallama://jobs/active` and `locallama://jobs/progress/{jobId}` URIs are emitted as monitoring metadata but are not load-bearing for agent polling.
+
+### Worst-case `status` + `reasons` array, not a flat condition list
+
+A single `status` enum (`"healthy" | "contended" | "degraded"`) gives agents a cheap branching signal. A parallel `reasons` array of active condition codes (`"local_slot_benchmark_contention"`, `"benchmark_queued"`, `"provider_unavailable"`, `"provider_unreachable"`) preserves full diagnostic detail when multiple conditions are active simultaneously. Priority order: `degraded > contended > healthy`. This is the same pattern as HTTP status codes with a body — fast path cheap, diagnostic path complete.
+
+A flat array of conditions was rejected because it forces every caller to iterate and check membership rather than switch on one value.
+
+### Slot-aware structure, not flat provider enumeration
+
+Ollama, LM Studio, and llama.cpp share a single VRAM-constrained execution slot (see ADR 0001). Enumerating them individually implies they have independent slots, which they do not. A dedicated `local_slot` block reflects this architectural reality and matches the `local_slot_contended` vocabulary already in `QueuedRouteTaskResult`. Remote providers each have independent slots and are enumerated individually in `remote_providers`.
+
+### `queued_jobs` from job store, not rate limiter
+
+The rate limiter holds in-memory scheduling state that rehydrates lazily after a server restart. The job store (SQLite) is the system of record for job lifecycle and has the correct count immediately after restart. Using the job store also keeps `get_system_state` consistent with `get_task_status`, which already reads from it. The query is a cheap `COUNT WHERE status = 'queued' AND is_local = ?`.
+
+### State-driven `poll_again_after_ms`
+
+`healthy → 30 000 ms`, `contended → 5 000 ms`, `degraded → 10 000 ms`. Contended polls more aggressively because a benchmark finishing frees the local slot — an event worth catching quickly. Degraded polls less aggressively because an unavailable provider requires external action; hammering the endpoint wastes calls. This follows the pattern established by `get_task_status`.
+
+## Response schema
+
+```typescript
+{
+  status: "healthy" | "contended" | "degraded";
+  reasons: Array<
+    | "local_slot_benchmark_contention"
+    | "benchmark_queued"
+    | "provider_unavailable"
+    | "provider_unreachable"
+  >;
+  poll_again_after_ms: number;
+  local_slot: {
+    status: "inference" | "benchmark" | "idle";
+    queued_jobs: number;           // job store
+    active_benchmark_runs: number; // rate limiter
+    queued_benchmark_runs: number; // rate limiter
+  };
+  remote_providers: Array<{
+    id: string;
+    cost_class: "local" | "free" | "paid";
+    available: boolean;            // circuit breaker
+    queued_jobs: number;           // job store
+  }>;
+}
+```
+
+## Backward compatibility
+
+`_queue_alert`, `_server_reminder`, and `benchmark_contention` on `QueuedRouteTaskResult` are unchanged. `get_system_state` is additive.
+
+## Considered options
+
+**Expand ambient metadata on existing tools** — attach system state to every `route_task` / `get_task_status` response. Rejected: callers with no active task have no way to observe system state, and bloating every response with provider enumeration increases payload size on the hot path.
+
+**MCP resource URI** — expose `locallama://system/state` as a readable resource. Rejected: no `poll_again_after_ms` guidance, requires clients to use `read_resource` rather than `call_tool`, and adds a second surface to keep synchronized with the type system.
+
+**Per-provider separate tools** — `get_local_slot_state`, `get_provider_state`. Rejected: forces callers to make multiple round-trips to build a picture of overall system health.

--- a/src/index.ts
+++ b/src/index.ts
@@ -418,6 +418,10 @@ export class LocalLamaMcpServer {
                   }
                   return await routingModule.cancelTask(taskId);
                 }
+                case 'get_system_state': {
+                  const { getSystemState } = await import('./modules/api-integration/system-state/index.js');
+                  return await getSystemState();
+                }
                 case 'reload_config':
                   return reloadConfig();
                 case 'get_free_models':

--- a/src/modules/api-integration/routing/types.ts
+++ b/src/modules/api-integration/routing/types.ts
@@ -107,6 +107,36 @@ export type Job = {
   model?: string;
 };
 
+export type SystemStateStatus = 'healthy' | 'contended' | 'degraded';
+
+export type SystemStateReason =
+  | 'local_slot_benchmark_contention'
+  | 'benchmark_queued'
+  | 'provider_unavailable'
+  | 'provider_unreachable';
+
+export interface SystemStateLocalSlot {
+  status: 'inference' | 'benchmark' | 'idle';
+  queued_jobs: number;
+  active_benchmark_runs: number;
+  queued_benchmark_runs: number;
+}
+
+export interface SystemStateRemoteProvider {
+  id: string;
+  cost_class: 'local' | 'free' | 'paid';
+  available: boolean;
+  queued_jobs: number;
+}
+
+export interface SystemStateResult {
+  status: SystemStateStatus;
+  reasons: SystemStateReason[];
+  poll_again_after_ms: number;
+  local_slot: SystemStateLocalSlot;
+  remote_providers: SystemStateRemoteProvider[];
+}
+
 export interface IRouter {
   routeTask(params: RouteTaskParams): Promise<QueuedRouteTaskResult>;
   preemptiveRouting(params: RouteTaskParams): Promise<RouteTaskResult>;

--- a/src/modules/api-integration/system-state/index.ts
+++ b/src/modules/api-integration/system-state/index.ts
@@ -1,0 +1,66 @@
+import { getProviderRegistry } from '../../core/provider/index.js';
+import { getQueuedJobCounts } from '../../job-store/db.js';
+import type {
+  SystemStateResult,
+  SystemStateReason,
+  SystemStateStatus,
+} from '../routing/types.js';
+
+const POLL_MS: Record<SystemStateStatus, number> = {
+  healthy: 30_000,
+  contended: 5_000,
+  degraded: 10_000,
+};
+
+export async function getSystemState(): Promise<SystemStateResult> {
+  const registry = getProviderRegistry();
+  const localStats = registry.getLocalExecutionQueueStats();
+  const counts = await getQueuedJobCounts();
+
+  const localSlotStatus =
+    localStats.activeBenchmarks > 0
+      ? ('benchmark' as const)
+      : localStats.activeCount > 0
+        ? ('inference' as const)
+        : ('idle' as const);
+
+  const reasons: SystemStateReason[] = [];
+
+  if (localStats.activeBenchmarks > 0) reasons.push('local_slot_benchmark_contention');
+  if (localStats.queuedBenchmarks > 0) reasons.push('benchmark_queued');
+
+  const remoteProviders = registry
+    .list()
+    .filter((p) => !p.isLocal)
+    .map((p) => {
+      const available = registry.isAvailable(p.id);
+      if (!available) reasons.push('provider_unavailable');
+      return {
+        id: p.id,
+        cost_class: p.costClass,
+        available,
+        queued_jobs: counts.byProvider[p.id] ?? 0,
+      };
+    });
+
+  const status: SystemStateStatus = reasons.some(
+    (r) => r === 'provider_unavailable' || r === 'provider_unreachable',
+  )
+    ? 'degraded'
+    : reasons.length > 0
+      ? 'contended'
+      : 'healthy';
+
+  return {
+    status,
+    reasons: [...new Set(reasons)],
+    poll_again_after_ms: POLL_MS[status],
+    local_slot: {
+      status: localSlotStatus,
+      queued_jobs: counts.local,
+      active_benchmark_runs: localStats.activeBenchmarks,
+      queued_benchmark_runs: localStats.queuedBenchmarks,
+    },
+    remote_providers: remoteProviders,
+  };
+}

--- a/src/modules/api-integration/tool-definition/index.ts
+++ b/src/modules/api-integration/tool-definition/index.ts
@@ -152,6 +152,20 @@ class ToolDefinitionProvider implements IToolDefinitionProvider {
         }
       },
       {
+        name: 'get_system_state',
+        description:
+          'Return a structured snapshot of current runtime health: local slot occupancy (inference vs benchmark vs idle), ' +
+          'queue depths, and remote provider availability. ' +
+          'Use this to determine why a task is delayed without needing WebSocket access. ' +
+          'The response includes a top-level status ("healthy" | "contended" | "degraded"), a reasons array of active ' +
+          'condition codes, and a poll_again_after_ms hint for backoff scheduling.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+        },
+      },
+      {
         name: 'reload_config',
         description:
           'Reload runtime configuration from the project .env file and apply only hot-reloadable fields. ' +

--- a/src/modules/job-store/db.ts
+++ b/src/modules/job-store/db.ts
@@ -306,6 +306,33 @@ export async function getTask(id: string): Promise<PersistedTask | undefined> {
   }
 }
 
+export interface QueuedJobCounts {
+  local: number;
+  byProvider: Record<string, number>;
+}
+
+export async function getQueuedJobCounts(): Promise<QueuedJobCounts> {
+  if (!dbInstance) return { local: 0, byProvider: {} };
+  try {
+    const rows = await dbInstance.all<{ is_local: number | null; provider_id: string | null; count: number }[]>(
+      `SELECT is_local, provider_id, COUNT(*) AS count FROM jobs WHERE status = 'queued' GROUP BY is_local, provider_id`
+    );
+    let local = 0;
+    const byProvider: Record<string, number> = {};
+    for (const row of rows) {
+      if (row.is_local === 1) {
+        local += row.count;
+      } else if (row.provider_id) {
+        byProvider[row.provider_id] = (byProvider[row.provider_id] ?? 0) + row.count;
+      }
+    }
+    return { local, byProvider };
+  } catch (error) {
+    logger.error('Failed to get queued job counts:', error);
+    return { local: 0, byProvider: {} };
+  }
+}
+
 /**
  * Compute queue position for a job at read time (ADR 0002).
  * Counts queued jobs in the same slot (local vs remote) with an earlier or equal rowid.

--- a/src/modules/job-store/index.ts
+++ b/src/modules/job-store/index.ts
@@ -15,6 +15,7 @@ export {
   updateTask,
   getTask,
   getQueuePositionForJob,
+  getQueuedJobCounts,
 } from './db.js';
 export { recoverInProgressJobs } from './recovery.js';
 export { refreshAlertState, isAlertActive, buildQueueAlert } from './alert.js';

--- a/test/modules/api-integration/system-state.test.ts
+++ b/test/modules/api-integration/system-state.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.unstable_mockModule('../../../dist/utils/logger.js', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const mockGetQueuedJobCounts = jest.fn<() => Promise<{ local: number; byProvider: Record<string, number> }>>();
+
+jest.unstable_mockModule('../../../dist/modules/job-store/db.js', () => ({
+  getQueuedJobCounts: mockGetQueuedJobCounts,
+}));
+
+const mockGetLocalExecutionQueueStats = jest.fn<() => { activeCount: number; queuedCount: number; activeBenchmarks: number; queuedBenchmarks: number }>();
+const mockList = jest.fn<() => { id: string; isLocal: boolean; costClass: 'local' | 'free' | 'paid' }[]>();
+const mockIsAvailable = jest.fn<(id: string) => boolean>();
+
+jest.unstable_mockModule('../../../dist/modules/core/provider/index.js', () => ({
+  getProviderRegistry: () => ({
+    getLocalExecutionQueueStats: mockGetLocalExecutionQueueStats,
+    list: mockList,
+    isAvailable: mockIsAvailable,
+  }),
+}));
+
+// ── Module import (after mocks) ───────────────────────────────────────────────
+
+const { getSystemState } = await import('../../../dist/modules/api-integration/system-state/index.js');
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('getSystemState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetQueuedJobCounts.mockResolvedValue({ local: 0, byProvider: {} });
+    mockList.mockReturnValue([]);
+    mockIsAvailable.mockReturnValue(true);
+  });
+
+  it('returns healthy status when local slot is idle and no remote providers are down', async () => {
+    mockGetLocalExecutionQueueStats.mockReturnValue({
+      activeCount: 0,
+      queuedCount: 0,
+      activeBenchmarks: 0,
+      queuedBenchmarks: 0,
+    });
+
+    const state = await getSystemState();
+
+    expect(state.status).toBe('healthy');
+    expect(state.reasons).toHaveLength(0);
+    expect(state.poll_again_after_ms).toBe(30_000);
+    expect(state.local_slot.status).toBe('idle');
+    expect(state.local_slot.queued_jobs).toBe(0);
+    expect(state.local_slot.active_benchmark_runs).toBe(0);
+    expect(state.local_slot.queued_benchmark_runs).toBe(0);
+    expect(state.remote_providers).toHaveLength(0);
+  });
+
+  it('returns healthy with inference status when a task job is active', async () => {
+    mockGetLocalExecutionQueueStats.mockReturnValue({
+      activeCount: 1,
+      queuedCount: 0,
+      activeBenchmarks: 0,
+      queuedBenchmarks: 0,
+    });
+    mockGetQueuedJobCounts.mockResolvedValue({ local: 2, byProvider: {} });
+
+    const state = await getSystemState();
+
+    expect(state.status).toBe('healthy');
+    expect(state.local_slot.status).toBe('inference');
+    expect(state.local_slot.queued_jobs).toBe(2);
+  });
+
+  it('returns contended with local_slot_benchmark_contention when a benchmark is active', async () => {
+    mockGetLocalExecutionQueueStats.mockReturnValue({
+      activeCount: 1,
+      queuedCount: 0,
+      activeBenchmarks: 1,
+      queuedBenchmarks: 0,
+    });
+
+    const state = await getSystemState();
+
+    expect(state.status).toBe('contended');
+    expect(state.reasons).toContain('local_slot_benchmark_contention');
+    expect(state.reasons).not.toContain('benchmark_queued');
+    expect(state.poll_again_after_ms).toBe(5_000);
+    expect(state.local_slot.status).toBe('benchmark');
+    expect(state.local_slot.active_benchmark_runs).toBe(1);
+  });
+
+  it('includes benchmark_queued reason when benchmarks are waiting in queue', async () => {
+    mockGetLocalExecutionQueueStats.mockReturnValue({
+      activeCount: 1,
+      queuedCount: 1,
+      activeBenchmarks: 1,
+      queuedBenchmarks: 2,
+    });
+
+    const state = await getSystemState();
+
+    expect(state.status).toBe('contended');
+    expect(state.reasons).toContain('local_slot_benchmark_contention');
+    expect(state.reasons).toContain('benchmark_queued');
+    expect(state.local_slot.queued_benchmark_runs).toBe(2);
+  });
+
+  it('returns degraded with provider_unavailable when a remote provider circuit is open', async () => {
+    mockGetLocalExecutionQueueStats.mockReturnValue({
+      activeCount: 0,
+      queuedCount: 0,
+      activeBenchmarks: 0,
+      queuedBenchmarks: 0,
+    });
+    mockList.mockReturnValue([{ id: 'openrouter', isLocal: false, costClass: 'free' }]);
+    mockIsAvailable.mockReturnValue(false);
+    mockGetQueuedJobCounts.mockResolvedValue({ local: 0, byProvider: { openrouter: 1 } });
+
+    const state = await getSystemState();
+
+    expect(state.status).toBe('degraded');
+    expect(state.reasons).toContain('provider_unavailable');
+    expect(state.poll_again_after_ms).toBe(10_000);
+    expect(state.remote_providers).toHaveLength(1);
+    expect(state.remote_providers[0]).toMatchObject({
+      id: 'openrouter',
+      cost_class: 'free',
+      available: false,
+      queued_jobs: 1,
+    });
+  });
+
+  it('degraded beats contended when both conditions are active', async () => {
+    mockGetLocalExecutionQueueStats.mockReturnValue({
+      activeCount: 1,
+      queuedCount: 0,
+      activeBenchmarks: 1,
+      queuedBenchmarks: 0,
+    });
+    mockList.mockReturnValue([{ id: 'openrouter', isLocal: false, costClass: 'free' }]);
+    mockIsAvailable.mockReturnValue(false);
+
+    const state = await getSystemState();
+
+    expect(state.status).toBe('degraded');
+    expect(state.reasons).toContain('local_slot_benchmark_contention');
+    expect(state.reasons).toContain('provider_unavailable');
+  });
+
+  it('deduplicates provider_unavailable when multiple providers are down', async () => {
+    mockGetLocalExecutionQueueStats.mockReturnValue({
+      activeCount: 0,
+      queuedCount: 0,
+      activeBenchmarks: 0,
+      queuedBenchmarks: 0,
+    });
+    mockList.mockReturnValue([
+      { id: 'openrouter', isLocal: false, costClass: 'free' },
+      { id: 'openai', isLocal: false, costClass: 'paid' },
+    ]);
+    mockIsAvailable.mockReturnValue(false);
+
+    const state = await getSystemState();
+
+    expect(state.status).toBe('degraded');
+    expect(state.reasons.filter((r) => r === 'provider_unavailable')).toHaveLength(1);
+    expect(state.remote_providers).toHaveLength(2);
+  });
+
+  it('excludes local providers from remote_providers array', async () => {
+    mockGetLocalExecutionQueueStats.mockReturnValue({
+      activeCount: 0,
+      queuedCount: 0,
+      activeBenchmarks: 0,
+      queuedBenchmarks: 0,
+    });
+    mockList.mockReturnValue([
+      { id: 'ollama', isLocal: true, costClass: 'local' },
+      { id: 'lm-studio', isLocal: true, costClass: 'local' },
+      { id: 'openrouter', isLocal: false, costClass: 'free' },
+    ]);
+    mockIsAvailable.mockReturnValue(true);
+
+    const state = await getSystemState();
+
+    expect(state.remote_providers).toHaveLength(1);
+    expect(state.remote_providers[0].id).toBe('openrouter');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `get_system_state` zero-argument MCP tool returning a structured runtime health snapshot
- Response includes top-level `status` (`healthy|contended|degraded`), `reasons` array, `poll_again_after_ms` hint, `local_slot` block, and `remote_providers` array
- Local slot covers Ollama, LM Studio, and llama.cpp as a single VRAM-constrained unit
- Queue depths read from the persistent job store (authoritative after restart); benchmark occupancy from rate limiter
- Adds `getQueuedJobCounts()` to the job store for cheap per-slot COUNT queries
- Adds ADR 0003 documenting the tool-vs-resource and slot-aware structure decisions
- Updates `CONTEXT.md` with `System State` term and extends `Local Inference Slot` to include llama.cpp

## Test plan

- [x] 8 unit tests covering: healthy/idle, healthy/inference, contended (active benchmark), contended (queued benchmarks), degraded (provider unavailable), degraded+contended (worst-case wins), reason deduplication, local providers excluded from `remote_providers`
- [x] Full suite: 423/423 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)