### PR TITLE
feat(llama-cpp): GGUF metadata pre-read and direct CLI inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,18 @@
 # Claude Code local project config (machine-specific paths, session state)
 .claude/
 
+# AI agent local state/config (machine-specific; usually not useful in Git)
+.codex/
+.agents/
+.cursor/
+.windsurf/
+.continue/
+.aider*
+.qodo/
+.augment/
+.cody/
+.antigravitycli/
+
 # Legacy Cline/Roo specific IDE and tool configuration
 .clinerules-architect
 .clinerules-ask
@@ -118,4 +130,5 @@ locallama.log.1.gz
 locallama.log.2.gz
 locallama.log.3.gz
 locallama.log.4.gz
+.claude/settings.local.json
 .claude/settings.local.json

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -55,6 +55,10 @@ export interface Config {
   llamaCppHealthProbeEnabled: boolean;
   llamaCppHealthProbePrompt: string;
   llamaCppHealthProbeTimeoutMs: number;
+  /** Optional context window cap applied when building --ctx-size flag from GGUF metadata. */
+  llamaCppMaxCtx?: number;
+  /** Extra flags appended to recommended GGUF flags when spawning llama-server. */
+  llamaCppServerFlags: string[];
 
   // Model configuration
   defaultLocalModel: string;
@@ -151,6 +155,8 @@ export const RESTART_REQUIRED_CONFIG_FIELDS = [
   'llamaCppModelPath',
   'llamaCppPort',
   'llamaCppStartupTimeoutMs',
+  'llamaCppMaxCtx',
+  'llamaCppServerFlags',
   'openRouterApiKey',
   'benchmark.resultsPath',
   'cacheEnabled',
@@ -240,6 +246,10 @@ function buildConfigFromEnv(env: NodeJS.ProcessEnv): Config {
     llamaCppHealthProbeEnabled: parseBool(env.LLAMA_CPP_HEALTH_PROBE_ENABLED, true),
     llamaCppHealthProbePrompt: env.LLAMA_CPP_HEALTH_PROBE_PROMPT || `write 'ok'`,
     llamaCppHealthProbeTimeoutMs: parseNumber(env.LLAMA_CPP_HEALTH_PROBE_TIMEOUT_MS, 10000, 1000),
+    llamaCppMaxCtx: env.LLAMA_CPP_MAX_CTX ? parseNumber(env.LLAMA_CPP_MAX_CTX, 0, 512) : undefined,
+    llamaCppServerFlags: env.LLAMA_CPP_SERVER_FLAGS
+      ? env.LLAMA_CPP_SERVER_FLAGS.trim().split(/\s+/).filter(Boolean)
+      : [],
 
     // Model configuration
     defaultLocalModel: env.DEFAULT_LOCAL_MODEL || 'llama2',

--- a/src/modules/llama-cpp/gguf.ts
+++ b/src/modules/llama-cpp/gguf.ts
@@ -1,0 +1,204 @@
+import { createReadStream } from 'fs';
+import { logger } from '../../utils/logger.js';
+
+export interface GgufMetadata {
+  architecture: string | null;
+  name: string | null;
+  chatTemplate: string | null;
+  contextLength: number | null;
+  isReasoningModel: boolean;
+  recommendedFlags: string[];
+}
+
+const GGUF_MAGIC = 'GGUF';
+
+const REASONING_NAME_PATTERNS = [/qwen3/i, /deepseek-r\d/i, /phi-4-reasoning/i];
+
+// GGUF value type constants
+const T_UINT8 = 0, T_INT8 = 1, T_UINT16 = 2, T_INT16 = 3;
+const T_UINT32 = 4, T_INT32 = 5, T_FLOAT32 = 6, T_BOOL = 7;
+const T_STRING = 8, T_ARRAY = 9, T_UINT64 = 10, T_INT64 = 11, T_FLOAT64 = 12;
+
+function readU32(buf: Buffer, offset: number): number {
+  return buf.readUInt32LE(offset);
+}
+
+function readU64(buf: Buffer, offset: number): number {
+  return Number(buf.readBigUInt64LE(offset));
+}
+
+/**
+ * Returns the number of bytes occupied by a value of the given type starting at buf[offset].
+ * For composite types (STRING, ARRAY) this reads length fields from the buffer.
+ */
+function valueSize(type: number, buf: Buffer, offset: number): number {
+  switch (type) {
+    case T_UINT8: case T_INT8: case T_BOOL: return 1;
+    case T_UINT16: case T_INT16: return 2;
+    case T_UINT32: case T_INT32: case T_FLOAT32: return 4;
+    case T_UINT64: case T_INT64: case T_FLOAT64: return 8;
+    case T_STRING: {
+      const len = readU64(buf, offset);
+      return 8 + len;
+    }
+    case T_ARRAY: {
+      const elemType = readU32(buf, offset);
+      const count = readU64(buf, offset + 4);
+      let total = 12; // 4 (elem_type) + 8 (count)
+      let elemOff = offset + 12;
+      for (let i = 0; i < count; i++) {
+        const s = valueSize(elemType, buf, elemOff);
+        total += s;
+        elemOff += s;
+      }
+      return total;
+    }
+    default:
+      throw new Error(`Unknown GGUF value type: ${type}`);
+  }
+}
+
+/** Extract a string or numeric value; returns null for unsupported types. */
+function extractValue(type: number, buf: Buffer, offset: number): string | number | null {
+  switch (type) {
+    case T_UINT32: case T_INT32: return readU32(buf, offset);
+    case T_UINT64: case T_INT64: return readU64(buf, offset);
+    case T_STRING: {
+      const len = readU64(buf, offset);
+      return buf.slice(offset + 8, offset + 8 + len).toString('utf-8');
+    }
+    default: return null;
+  }
+}
+
+function buildFlags(
+  chatTemplate: string | null,
+  name: string | null,
+  contextLength: number | null,
+  maxCtx: number | null,
+): { isReasoningModel: boolean; recommendedFlags: string[] } {
+  const isReasoningModel =
+    (chatTemplate !== null && chatTemplate.includes('<think>')) ||
+    (name !== null && REASONING_NAME_PATTERNS.some((r) => r.test(name)));
+
+  const flags: string[] = [];
+  if (isReasoningModel) flags.push('--reasoning-format', 'none');
+  if (contextLength !== null) {
+    const ctx = maxCtx !== null ? Math.min(contextLength, maxCtx) : contextLength;
+    flags.push('--ctx-size', String(ctx));
+  }
+  return { isReasoningModel, recommendedFlags: flags };
+}
+
+async function readFirstBytes(filePath: string, maxBytes: number): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let bytesRead = 0;
+    const stream = createReadStream(filePath, { highWaterMark: 64 * 1024 });
+    const finish = () => resolve(Buffer.concat(chunks));
+    stream.on('data', (chunk: Buffer | string) => {
+      const chunkBuf: Buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+      const remaining = maxBytes - bytesRead;
+      if (remaining <= 0) { stream.destroy(); return; }
+      const slice = chunkBuf.length <= remaining ? chunkBuf : chunkBuf.slice(0, remaining);
+      chunks.push(slice);
+      bytesRead += slice.length;
+      if (bytesRead >= maxBytes) stream.destroy();
+    });
+    stream.on('end', finish);
+    stream.on('close', finish);
+    stream.on('error', reject);
+  });
+}
+
+const NULL_RESULT: GgufMetadata = {
+  architecture: null, name: null, chatTemplate: null, contextLength: null,
+  isReasoningModel: false, recommendedFlags: [],
+};
+
+/**
+ * Read GGUF file header and extract model metadata without loading the model.
+ * Returns a result with all-null fields on any read or parse failure.
+ *
+ * @param maxCtx - Optional cap for --ctx-size flag (LLAMA_CPP_MAX_CTX)
+ */
+export async function readGgufMetadata(
+  modelPath: string,
+  maxCtx: number | null = null,
+): Promise<GgufMetadata> {
+  try {
+    const buf = await readFirstBytes(modelPath, 4 * 1024 * 1024);
+
+    if (buf.length < 24) {
+      logger.warn(`GGUF file too small to parse header: ${modelPath}`);
+      return { ...NULL_RESULT };
+    }
+
+    const magic = buf.slice(0, 4).toString('ascii');
+    if (magic !== GGUF_MAGIC) {
+      logger.warn(`Not a GGUF file (bad magic "${magic}"): ${modelPath}`);
+      return { ...NULL_RESULT };
+    }
+
+    const version = readU32(buf, 4);
+    if (version < 2) {
+      logger.warn(`Unsupported GGUF version ${version} (need ≥ 2): ${modelPath}`);
+      return { ...NULL_RESULT };
+    }
+
+    // Version 2+: n_tensors @ 8 (uint64), n_kv @ 16 (uint64)
+    const nKv = readU64(buf, 16);
+    let pos = 24;
+
+    let architecture: string | null = null;
+    let name: string | null = null;
+    let chatTemplate: string | null = null;
+    let contextLength: number | null = null;
+
+    for (let i = 0; i < nKv && pos < buf.length; i++) {
+      try {
+        if (pos + 8 > buf.length) break;
+        const keyLen = readU64(buf, pos);
+        pos += 8;
+        if (pos + keyLen > buf.length) break;
+        const key = buf.slice(pos, pos + keyLen).toString('utf-8');
+        pos += keyLen;
+
+        if (pos + 4 > buf.length) break;
+        const valType = readU32(buf, pos);
+        pos += 4;
+
+        const isTarget =
+          key === 'general.architecture' ||
+          key === 'general.name' ||
+          key === 'tokenizer.chat_template' ||
+          key.endsWith('.context_length');
+
+        const size = valueSize(valType, buf, pos);
+
+        if (isTarget) {
+          const val = extractValue(valType, buf, pos);
+          if (val !== null) {
+            if (key === 'general.architecture') architecture = String(val);
+            else if (key === 'general.name') name = String(val);
+            else if (key === 'tokenizer.chat_template') chatTemplate = String(val);
+            else if (key.endsWith('.context_length') && typeof val === 'number') contextLength = val;
+          }
+        }
+
+        pos += size;
+      } catch {
+        // Buffer boundary hit mid-parse — stop with what we have
+        break;
+      }
+    }
+
+    const { isReasoningModel, recommendedFlags } = buildFlags(chatTemplate, name, contextLength, maxCtx);
+    return { architecture, name, chatTemplate, contextLength, isReasoningModel, recommendedFlags };
+  } catch (err) {
+    logger.warn(
+      `Failed to read GGUF metadata from ${modelPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { ...NULL_RESULT };
+  }
+}

--- a/src/modules/llama-cpp/index.ts
+++ b/src/modules/llama-cpp/index.ts
@@ -15,6 +15,7 @@
  */
 
 import axios, { AxiosError } from 'axios';
+import { spawn } from 'child_process';
 import { config } from '../../config/index.js';
 import { logger } from '../../utils/logger.js';
 import { Model } from '../../types/index.js';
@@ -33,6 +34,7 @@ import { InferenceTimeoutError } from '../utils/inferenceTimeout.js';
 import { sanitizeErrorForLogging } from '../utils/sanitizeErrorForLogging.js';
 import { discoverLlamaBinaries } from './discovery.js';
 import { LlamaServerManager } from './manager.js';
+import { readGgufMetadata, GgufMetadata } from './gguf.js';
 
 function isDegenerate(text: string): boolean {
   if (!text || /^\s*$/.test(text)) return true; // empty or whitespace
@@ -65,6 +67,7 @@ export const llamaCppModule = {
     managedProcess: false,
     resolvedPort: null,
     restartCount: 0,
+    modelMetadata: null,
   } as LlamaCppCapabilities,
 
   /** Managed child process manager. */
@@ -72,6 +75,9 @@ export const llamaCppModule = {
 
   /** Resolved local binaries and their capabilities. */
   binaries: null as LlamaBinarySet | null,
+
+  /** GGUF metadata read from the configured model file. Null until populated. */
+  modelMetadata: null as GgufMetadata | null,
 
   /** In-memory cache of models reported by the server. */
   cachedModels: [] as LlamaCppApiModel[],
@@ -163,8 +169,15 @@ export const llamaCppModule = {
 
     if (binary && model) {
       try {
+        // Read GGUF metadata to inform flag selection before spawning
+        const metadata = await readGgufMetadata(model, config.llamaCppMaxCtx ?? null);
+        this.modelMetadata = metadata;
+        this.capabilities.modelMetadata = metadata;
+
+        const extraFlags = [...metadata.recommendedFlags, ...(config.llamaCppServerFlags ?? [])];
+
         const port = await this.manager.findFreePort(config.llamaCppPort);
-        await this.manager.spawnServer(binary, model, port);
+        await this.manager.spawnServer(binary, model, port, extraFlags);
         
         // Update config endpoint for subsequent calls
         (config as any).llamaCppEndpoint = `http://localhost:${port}`;
@@ -372,6 +385,83 @@ export const llamaCppModule = {
         error: this.classifyError(error instanceof Error ? error : new Error(String(error))),
       };
     }
+  },
+
+  /**
+   * Execute a task via the llama-cli binary (subprocess, no server required).
+   * Returns captured, filtered stdout.
+   */
+  async executeTaskViaCli(
+    modelId: string,
+    task: string,
+    options?: { timeoutMs?: number; systemPrompt?: string; temperature?: number; maxTokens?: number },
+  ): Promise<{ content: string; model: string }> {
+    const cliBin = this.binaries?.cli;
+    if (!cliBin) {
+      throw new Error('llama-cli binary not available');
+    }
+
+    const modelPath = config.llamaCppModelPath;
+    if (!modelPath) {
+      throw new Error('No model path configured (LLAMA_CPP_MODEL_PATH)');
+    }
+
+    const temperature = options?.temperature ?? config.defaultModelConfig?.temperature ?? 0.7;
+    const maxTokens = options?.maxTokens ?? config.defaultModelConfig?.maxTokens ?? 512;
+    const recommendedFlags = this.modelMetadata?.recommendedFlags ?? [];
+
+    const prompt = options?.systemPrompt
+      ? `${options.systemPrompt}\n\n${task}`
+      : task;
+
+    const args = [
+      '--model', modelPath,
+      '--prompt', prompt,
+      '--n-predict', String(maxTokens),
+      '--temp', String(temperature),
+      '--no-display-prompt',
+      '--log-disable',
+      ...recommendedFlags,
+    ];
+
+    return new Promise((resolve, reject) => {
+      const proc = spawn(cliBin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+      const chunks: Buffer[] = [];
+
+      const timeoutMs = options?.timeoutMs && options.timeoutMs > 0 ? options.timeoutMs : 30000;
+      const timer = setTimeout(() => {
+        proc.kill('SIGKILL');
+        reject(new Error(`llama-cli timeout after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      proc.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
+
+      proc.on('exit', (code) => {
+        clearTimeout(timer);
+        if (code !== 0) {
+          reject(new Error(`llama-cli exited with code ${code}`));
+          return;
+        }
+
+        const raw = Buffer.concat(chunks).toString('utf-8');
+        const filtered = raw
+          .split('\n')
+          .filter((line) => {
+            if (/^llama_/.test(line)) return false;
+            if (/^\[/.test(line)) return false;
+            return true;
+          })
+          .join('\n')
+          .trim();
+
+        resolve({ content: filtered, model: modelId });
+      });
+
+      proc.on('error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
   },
 
   /**

--- a/src/modules/llama-cpp/manager.ts
+++ b/src/modules/llama-cpp/manager.ts
@@ -12,6 +12,7 @@ export class LlamaServerManager {
   private lastBinaryPath: string | null = null;
   private lastModelPath: string | null = null;
   private lastPort: number | null = null;
+  private lastExtraFlags: string[] = [];
 
   /**
    * Get the current restart count.
@@ -48,17 +49,20 @@ export class LlamaServerManager {
 
   /**
    * Spawn llama-server as a child process and wait for readiness.
+   * @param extraFlags - Additional flags to append (from GGUF metadata + user overrides)
    */
-  async spawnServer(binaryPath: string, modelPath: string, port: number): Promise<void> {
+  async spawnServer(binaryPath: string, modelPath: string, port: number, extraFlags: string[] = []): Promise<void> {
     this.lastBinaryPath = binaryPath;
     this.lastModelPath = modelPath;
     this.lastPort = port;
+    this.lastExtraFlags = extraFlags;
     this.isStopping = false;
 
     const args = [
       '--model', modelPath,
       '--port', port.toString(),
       '--no-mmap',
+      ...extraFlags,
     ];
 
     logger.info(`Spawning llama-server: ${binaryPath} ${args.join(' ')}`);
@@ -137,7 +141,7 @@ export class LlamaServerManager {
     setTimeout(async () => {
       if (this.lastBinaryPath && this.lastModelPath && this.lastPort !== null && !this.isStopping) {
         try {
-          await this.spawnServer(this.lastBinaryPath, this.lastModelPath, this.lastPort);
+          await this.spawnServer(this.lastBinaryPath, this.lastModelPath, this.lastPort, this.lastExtraFlags);
         } catch (error) {
           logger.error(`Failed to restart llama-server: ${error instanceof Error ? error.message : String(error)}`);
         }

--- a/src/modules/llama-cpp/types.ts
+++ b/src/modules/llama-cpp/types.ts
@@ -97,6 +97,8 @@ export interface LlamaCppCapabilities {
   resolvedPort: number | null;
   /** Number of times the managed server has been restarted. */
   restartCount: number;
+  /** GGUF metadata read from the model file before spawn. Null if not yet read or unavailable. */
+  modelMetadata: import('./gguf.js').GgufMetadata | null;
 }
 
 /** Resolved paths and capabilities of local llama.cpp binaries. */

--- a/test/modules/llama-cpp/cli-execution.test.ts
+++ b/test/modules/llama-cpp/cli-execution.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import EventEmitter from 'events';
+
+// --- mocks ----------------------------------------------------------------
+
+const configMock = {
+  llamaCppEndpoint: '',
+  llamaCppModelPath: '/models/test.gguf',
+  llamaCppCliBin: '',
+  llamaCppServerBin: '',
+  llamaCppPort: 8080,
+  llamaCppStartupTimeoutMs: 1000,
+  llamaCppHealthProbeEnabled: false,
+  llamaCppMaxCtx: undefined as number | undefined,
+  llamaCppServerFlags: [] as string[],
+  providerTimeoutMs: 5000,
+  defaultModelConfig: { temperature: 0.7, maxTokens: 512 },
+};
+
+jest.unstable_mockModule('../../../dist/config/index.js', () => ({
+  config: configMock,
+}));
+
+const loggerMock = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+jest.unstable_mockModule('../../../dist/utils/logger.js', () => ({
+  logger: loggerMock,
+}));
+
+const spawnMock = jest.fn<any>();
+jest.unstable_mockModule('child_process', () => ({
+  spawn: spawnMock,
+}));
+
+const discoverMock = jest.fn<any>();
+jest.unstable_mockModule('../../../dist/modules/llama-cpp/discovery.js', () => ({
+  discoverLlamaBinaries: discoverMock,
+}));
+
+const readGgufMetadataMock = jest.fn<any>();
+jest.unstable_mockModule('../../../dist/modules/llama-cpp/gguf.js', () => ({
+  readGgufMetadata: readGgufMetadataMock,
+}));
+
+jest.unstable_mockModule('axios', () => ({
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    isAxiosError: jest.fn(() => false),
+  },
+}));
+
+// --- imports -------------------------------------------------------------
+
+const { llamaCppModule } = await import('../../../dist/modules/llama-cpp/index.js');
+
+// -------------------------------------------------------------------------
+
+function makeCliProcess(stdoutOutput: string, exitCode = 0) {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = jest.fn();
+  proc.pid = 9999;
+  setTimeout(() => {
+    proc.stdout.emit('data', Buffer.from(stdoutOutput));
+    proc.emit('exit', exitCode, null);
+  }, 10);
+  return proc;
+}
+
+const DEFAULT_METADATA = {
+  architecture: 'llama',
+  name: 'Llama-3-8B',
+  chatTemplate: null,
+  contextLength: 4096,
+  isReasoningModel: false,
+  recommendedFlags: ['--ctx-size', '4096'],
+};
+
+describe('llamaCppModule.executeTaskViaCli', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    configMock.llamaCppEndpoint = '';
+    configMock.llamaCppModelPath = '/models/test.gguf';
+    configMock.llamaCppServerFlags = [];
+
+    discoverMock.mockResolvedValue({
+      server: null,
+      cli: '/usr/local/bin/llama-cli',
+      run: null,
+      version: '1.0',
+      supportsReasoningFormat: true,
+      searchedPaths: [],
+    });
+
+    readGgufMetadataMock.mockResolvedValue(DEFAULT_METADATA);
+
+    llamaCppModule.capabilities.managedProcess = false;
+    llamaCppModule.capabilities.modelMetadata = DEFAULT_METADATA;
+    llamaCppModule.modelMetadata = DEFAULT_METADATA;
+    llamaCppModule.binaries = {
+      server: null,
+      cli: '/usr/local/bin/llama-cli',
+      run: null,
+      version: '1.0',
+      supportsReasoningFormat: true,
+      searchedPaths: [],
+    };
+  });
+
+  it('tracer bullet: spawns llama-cli and returns captured stdout', async () => {
+    spawnMock.mockReturnValue(makeCliProcess('Hello from the model!\n'));
+
+    const result = await llamaCppModule.executeTaskViaCli('m1', 'Say hello', {
+      timeoutMs: 2000,
+    });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/usr/local/bin/llama-cli',
+      expect.arrayContaining(['--model', '/models/test.gguf']),
+      expect.any(Object),
+    );
+    expect(result.content).toBe('Hello from the model!');
+  });
+
+  it('strips llama-cli debug/progress lines from output', async () => {
+    const rawOutput = [
+      'llama_load_model_from_file: using CPU backend',
+      '[debug] something internal',
+      'This is the actual response text.',
+      'llama_perf_sampler_print:    mirostat_mu = 0.000000',
+      'More response here.',
+    ].join('\n');
+
+    spawnMock.mockReturnValue(makeCliProcess(rawOutput));
+
+    const result = await llamaCppModule.executeTaskViaCli('m1', 'task', { timeoutMs: 2000 });
+
+    expect(result.content).toContain('This is the actual response text.');
+    expect(result.content).toContain('More response here.');
+    expect(result.content).not.toContain('llama_load_model_from_file');
+    expect(result.content).not.toContain('[debug]');
+  });
+
+  it('includes --reasoning-format none for reasoning models', async () => {
+    const reasoningMeta = {
+      ...DEFAULT_METADATA,
+      isReasoningModel: true,
+      recommendedFlags: ['--reasoning-format', 'none', '--ctx-size', '4096'],
+    };
+    llamaCppModule.modelMetadata = reasoningMeta;
+    llamaCppModule.capabilities.modelMetadata = reasoningMeta;
+
+    spawnMock.mockReturnValue(makeCliProcess('response text'));
+
+    await llamaCppModule.executeTaskViaCli('m1', 'task', { timeoutMs: 2000 });
+
+    const spawnArgs = spawnMock.mock.calls[0][1] as string[];
+    expect(spawnArgs).toContain('--reasoning-format');
+    expect(spawnArgs).toContain('none');
+  });
+
+  it('kills process with SIGKILL on timeout', async () => {
+    const proc = new EventEmitter() as any;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = jest.fn();
+    proc.pid = 9999;
+    // Never emits exit — simulates hung process
+
+    spawnMock.mockReturnValue(proc);
+
+    await expect(
+      llamaCppModule.executeTaskViaCli('m1', 'task', { timeoutMs: 100 }),
+    ).rejects.toThrow(/timeout/i);
+
+    expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('throws when CLI binary is not available', async () => {
+    llamaCppModule.binaries = {
+      server: null, cli: null, run: null,
+      version: null, supportsReasoningFormat: false, searchedPaths: [],
+    };
+
+    await expect(
+      llamaCppModule.executeTaskViaCli('m1', 'task', { timeoutMs: 2000 }),
+    ).rejects.toThrow(/llama-cli/i);
+  });
+
+  it('throws when model path is not configured', async () => {
+    configMock.llamaCppModelPath = undefined as any;
+
+    await expect(
+      llamaCppModule.executeTaskViaCli('m1', 'task', { timeoutMs: 2000 }),
+    ).rejects.toThrow(/model/i);
+  });
+
+  it('throws when CLI process exits with non-zero code', async () => {
+    spawnMock.mockReturnValue(makeCliProcess('', 1));
+
+    await expect(
+      llamaCppModule.executeTaskViaCli('m1', 'task', { timeoutMs: 2000 }),
+    ).rejects.toThrow();
+  });
+});

--- a/test/modules/llama-cpp/gguf.test.ts
+++ b/test/modules/llama-cpp/gguf.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import EventEmitter from 'events';
+
+// --- helpers ---------------------------------------------------------------
+
+// --- helpers ---------------------------------------------------------------
+
+/**
+ * Build a minimal GGUF v3 binary buffer with the given key-value pairs.
+ */
+function buildGgufBuffer(
+  kv: Array<{ key: string; value: string | number; type?: 'string' | 'uint32' | 'uint64' }>,
+): Buffer {
+  const parts: Buffer[] = [];
+
+  // Magic
+  parts.push(Buffer.from('GGUF', 'ascii'));
+
+  // Version 3
+  const version = Buffer.alloc(4);
+  version.writeUInt32LE(3, 0);
+  parts.push(version);
+
+  // n_tensors = 0 (uint64)
+  const nTensors = Buffer.alloc(8);
+  nTensors.writeBigUInt64LE(0n, 0);
+  parts.push(nTensors);
+
+  // n_kv = kv.length (uint64)
+  const nKv = Buffer.alloc(8);
+  nKv.writeBigUInt64LE(BigInt(kv.length), 0);
+  parts.push(nKv);
+
+  for (const entry of kv) {
+    const keyBuf = Buffer.from(entry.key, 'utf-8');
+
+    // key_len (uint64)
+    const keyLen = Buffer.alloc(8);
+    keyLen.writeBigUInt64LE(BigInt(keyBuf.length), 0);
+    parts.push(keyLen);
+    parts.push(keyBuf);
+
+    if (typeof entry.value === 'string') {
+      // value type = STRING (8)
+      const typeBuf = Buffer.alloc(4);
+      typeBuf.writeUInt32LE(8, 0);
+      parts.push(typeBuf);
+
+      const valBuf = Buffer.from(entry.value, 'utf-8');
+      const valLen = Buffer.alloc(8);
+      valLen.writeBigUInt64LE(BigInt(valBuf.length), 0);
+      parts.push(valLen);
+      parts.push(valBuf);
+    } else {
+      const useU64 = entry.type === 'uint64';
+      const typeBuf = Buffer.alloc(4);
+      typeBuf.writeUInt32LE(useU64 ? 10 : 4, 0); // 10=UINT64, 4=UINT32
+      parts.push(typeBuf);
+
+      if (useU64) {
+        const valBuf = Buffer.alloc(8);
+        valBuf.writeBigUInt64LE(BigInt(entry.value), 0);
+        parts.push(valBuf);
+      } else {
+        const valBuf = Buffer.alloc(4);
+        valBuf.writeUInt32LE(entry.value as number, 0);
+        parts.push(valBuf);
+      }
+    }
+  }
+
+  return Buffer.concat(parts);
+}
+
+// --- mocks ----------------------------------------------------------------
+
+const loggerMock = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+jest.unstable_mockModule('../../../dist/utils/logger.js', () => ({
+  logger: loggerMock,
+}));
+
+let fsReadStreamData: Buffer = Buffer.alloc(0);
+
+jest.unstable_mockModule('fs', () => {
+  return {
+    createReadStream: jest.fn().mockImplementation(() => {
+      const ee = new EventEmitter();
+      process.nextTick(() => {
+        ee.emit('data', fsReadStreamData);
+        ee.emit('end');
+      });
+      return ee;
+    }),
+  };
+});
+
+// --- imports -------------------------------------------------------------
+
+const { readGgufMetadata } = await import('../../../dist/modules/llama-cpp/gguf.js');
+const { createReadStream } = await import('fs');
+
+// -------------------------------------------------------------------------
+
+describe('readGgufMetadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fsReadStreamData = Buffer.alloc(0);
+  });
+
+  it('tracer bullet: parses architecture and name from a minimal GGUF', async () => {
+    fsReadStreamData = buildGgufBuffer([
+      { key: 'general.architecture', value: 'llama' },
+      { key: 'general.name', value: 'Llama-3-8B' },
+    ]);
+
+    const meta = await readGgufMetadata('/fake/model.gguf');
+
+    expect(meta.architecture).toBe('llama');
+    expect(meta.name).toBe('Llama-3-8B');
+    expect(meta.isReasoningModel).toBe(false);
+    expect(meta.recommendedFlags).not.toContain('--reasoning-format');
+  });
+
+  it('detects reasoning model when chat template contains <think>', async () => {
+    const chatTemplate = '{% if messages[0].role == "system" %}{%- set system_message = messages[0].content -%}{% endif %}{{- "<think>\n</think>\n" -}}{{ system_message }}';
+    fsReadStreamData = buildGgufBuffer([
+      { key: 'general.architecture', value: 'qwen2' },
+      { key: 'general.name', value: 'Qwen3-14B' },
+      { key: 'tokenizer.chat_template', value: chatTemplate },
+    ]);
+
+    const meta = await readGgufMetadata('/fake/qwen3.gguf');
+
+    expect(meta.isReasoningModel).toBe(true);
+    expect(meta.recommendedFlags).toContain('--reasoning-format');
+    expect(meta.recommendedFlags).toContain('none');
+  });
+
+  it('detects reasoning model from name pattern (Qwen3)', async () => {
+    fsReadStreamData = buildGgufBuffer([
+      { key: 'general.name', value: 'Qwen3-14B-Instruct' },
+    ]);
+
+    const meta = await readGgufMetadata('/fake/qwen3.gguf');
+
+    expect(meta.isReasoningModel).toBe(true);
+    expect(meta.recommendedFlags).toContain('--reasoning-format');
+  });
+
+  it('detects reasoning model from name pattern (DeepSeek-R1)', async () => {
+    fsReadStreamData = buildGgufBuffer([
+      { key: 'general.name', value: 'DeepSeek-R1-Distill-Qwen-7B' },
+    ]);
+
+    const meta = await readGgufMetadata('/fake/deepseek.gguf');
+
+    expect(meta.isReasoningModel).toBe(true);
+  });
+
+  it('does not flag normal model as reasoning model', async () => {
+    fsReadStreamData = buildGgufBuffer([
+      { key: 'general.architecture', value: 'llama' },
+      { key: 'general.name', value: 'Llama-3.1-8B-Instruct' },
+      { key: 'tokenizer.chat_template', value: '{{ user_message }}' },
+    ]);
+
+    const meta = await readGgufMetadata('/fake/llama.gguf');
+
+    expect(meta.isReasoningModel).toBe(false);
+    expect(meta.recommendedFlags).not.toContain('--reasoning-format');
+  });
+
+  it('extracts context length and adds --ctx-size flag', async () => {
+    fsReadStreamData = buildGgufBuffer([
+      { key: 'general.architecture', value: 'llama' },
+      { key: 'llama.context_length', value: 32768, type: 'uint32' },
+    ]);
+
+    const meta = await readGgufMetadata('/fake/model.gguf');
+
+    expect(meta.contextLength).toBe(32768);
+    expect(meta.recommendedFlags).toContain('--ctx-size');
+    expect(meta.recommendedFlags).toContain('32768');
+  });
+
+  it('caps context size to maxCtx when provided', async () => {
+    fsReadStreamData = buildGgufBuffer([
+      { key: 'llama.context_length', value: 131072, type: 'uint32' },
+    ]);
+
+    const meta = await readGgufMetadata('/fake/model.gguf', 4096);
+
+    expect(meta.contextLength).toBe(131072);
+    const ctxIdx = meta.recommendedFlags.indexOf('--ctx-size');
+    expect(ctxIdx).toBeGreaterThanOrEqual(0);
+    expect(meta.recommendedFlags[ctxIdx + 1]).toBe('4096');
+  });
+
+  it('handles architecture-specific context_length keys (qwen2.context_length)', async () => {
+    fsReadStreamData = buildGgufBuffer([
+      { key: 'general.architecture', value: 'qwen2' },
+      { key: 'qwen2.context_length', value: 65536, type: 'uint32' },
+    ]);
+
+    const meta = await readGgufMetadata('/fake/qwen2.gguf');
+
+    expect(meta.contextLength).toBe(65536);
+  });
+
+  it('returns null metadata on missing file', async () => {
+    (createReadStream as jest.Mock).mockImplementationOnce(() => {
+      const ee = new EventEmitter();
+      process.nextTick(() => ee.emit('error', new Error('ENOENT: no such file or directory')));
+      return ee;
+    });
+
+    const meta = await readGgufMetadata('/nonexistent/model.gguf');
+
+    expect(meta.architecture).toBeNull();
+    expect(meta.name).toBeNull();
+    expect(meta.contextLength).toBeNull();
+    expect(meta.isReasoningModel).toBe(false);
+    expect(meta.recommendedFlags).toEqual([]);
+    expect(loggerMock.warn).toHaveBeenCalled();
+  });
+
+  it('returns null metadata on invalid magic bytes', async () => {
+    fsReadStreamData = Buffer.from('NOTGGUF this is not a valid gguf file at all', 'ascii');
+
+    const meta = await readGgufMetadata('/fake/invalid.bin');
+
+    expect(meta.architecture).toBeNull();
+    expect(meta.isReasoningModel).toBe(false);
+    expect(loggerMock.warn).toHaveBeenCalled();
+  });
+
+  it('returns null metadata on too-small file', async () => {
+    fsReadStreamData = Buffer.from('GGU', 'ascii'); // only 3 bytes
+
+    const meta = await readGgufMetadata('/fake/tiny.gguf');
+
+    expect(meta.architecture).toBeNull();
+    expect(loggerMock.warn).toHaveBeenCalled();
+  });
+
+  it('returns partial metadata gracefully if buffer truncated mid-parse', async () => {
+    // Build a valid buffer but truncate it mid-way through the second KV pair
+    const full = buildGgufBuffer([
+      { key: 'general.architecture', value: 'llama' },
+      { key: 'general.name', value: 'Llama-3-8B' },
+    ]);
+    fsReadStreamData = full.slice(0, full.length - 5); // truncate last 5 bytes
+
+    // Should not throw; may return partial metadata
+    const meta = await readGgufMetadata('/fake/truncated.gguf');
+    expect(meta).toBeDefined();
+    expect(typeof meta.isReasoningModel).toBe('boolean');
+  });
+});


### PR DESCRIPTION
Closes #93, closes #95.

## Summary
- **#93 — GGUF metadata pre-read**: Parse the model file's GGUF header before spawning `llama-server` to derive flags up front (reasoning models get `--reasoning-format none`, ctx-size capped at the model's training max, etc.) rather than launching generic and hitting issues at inference time.
- **#95 — Direct CLI inference**: New `executeTaskViaCli` path spawns `llama-cli` as a subprocess so single-task scenarios skip server startup + HTTP entirely.
- Recommended GGUF flags + user-supplied `LLAMA_CPP_SERVER_FLAGS` are plumbed into the managed `spawnServer` call and preserved across crash-recovery restarts.
- New config: `LLAMA_CPP_MAX_CTX` (optional ctx cap) and `LLAMA_CPP_SERVER_FLAGS` (extra flags, appended after GGUF-derived ones — manual overrides still work).

## Test plan
- [x] `npm test -- test/modules/llama-cpp/gguf.test.ts test/modules/llama-cpp/cli-execution.test.ts` → 19 pass
- [x] `npm run build` (tsc) clean
- [x] Full `test/modules/llama-cpp/` suite: 83/85 pass; the 2 failures are pre-existing on `main` (manager.test.ts findFreePort tests hardcode port 8080, which is occupied on this dev box — unrelated to this diff)
- [ ] Smoke-test on a real reasoning-model GGUF (e.g. Qwen3) — confirm `--reasoning-format none` injected automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)