### PR TITLE
fix(server): robust stdio lifecycle — exit on disconnect, drop singleton, clean update restart

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import type { RouteTaskParams } from './modules/api-integration/routing/types.js
 import type { CostEstimationParams } from './modules/api-integration/cost-estimation/types.js';
 import type { OpenRouterBenchmarkConfig } from './modules/api-integration/openrouter-integration/types.js';
 import type { BenchmarkConfig, BenchmarkTaskParams } from './types/index.js';
-import { createLockFile, isLockFilePresent, removeLockFile, getLockFileInfo } from './utils/lock-file.js';
+import { createLockFile, isLockFilePresent, removeLockFile, getLockFileInfo, isLockFileProcessRunning } from './utils/lock-file.js';
 import type { LockFileInfo } from './utils/lock-file.js';
 import { setClientHints } from './modules/core/client/hints.js';
 import { checkForUpdates, runUpdate, runStartupCheck } from './modules/updater/index.js';
@@ -188,48 +188,49 @@ export class LocalLamaMcpServer {
    */
   private setupProcessSignalHandlers(): void {
     const signals = ['SIGINT', 'SIGTERM', 'SIGHUP'] as const;
-    
+
     signals.forEach(signal => {
       process.on(signal, () => {
-        if (this.isShuttingDown) return;
-        this.isShuttingDown = true;
-        
-        logger.info(`Received ${signal}, shutting down gracefully...`);
-        
-        // Use Promise.resolve to handle the async shutdown without issues in the event handler
-        Promise.resolve(this.shutdown())
-          .then(() => process.exit(0))
-          .catch(err => {
-            logger.error(`Error during shutdown after ${signal}:`, err);
-            process.exit(1);
-          });
+        this.gracefulExit(0, `signal ${signal}`);
       });
     });
+
+    // When the MCP client (e.g. Claude Code) goes away it closes our stdin. If
+    // it exits cleanly we also get SIGTERM/SIGHUP, but on a crash or hard kill
+    // no signal is delivered — stdin EOF is the only notification. Without this
+    // the process would be reparented to init and linger as an orphan, holding
+    // the lock file (and any ports). Treat stdin close as a shutdown request.
+    process.stdin.on('end', () => this.gracefulExit(0, 'stdin end (client disconnected)'));
+    process.stdin.on('close', () => this.gracefulExit(0, 'stdin close (client disconnected)'));
 
     // Handle uncaught exceptions and unhandled promise rejections
     process.on('uncaughtException', (err) => {
       logger.error('Uncaught exception:', err);
-      
-      if (this.isShuttingDown) return;
-      this.isShuttingDown = true;
-      
-      // Use Promise.resolve to handle the async shutdown without issues in the event handler
-      Promise.resolve(this.shutdown())
-        .then(() => process.exit(1))
-        .catch(() => process.exit(1));
+      this.gracefulExit(1, 'uncaughtException');
     });
 
     process.on('unhandledRejection', (reason) => {
       logger.error('Unhandled promise rejection:', reason);
-      
-      if (this.isShuttingDown) return;
-      this.isShuttingDown = true;
-      
-      // Use Promise.resolve to handle the async shutdown without issues in the event handler
-      Promise.resolve(this.shutdown())
-        .then(() => process.exit(1))
-        .catch(() => process.exit(1));
+      this.gracefulExit(1, 'unhandledRejection');
     });
+  }
+
+  /**
+   * Run the shutdown procedure exactly once and exit. Safe to call from any
+   * lifecycle trigger (signal, stdin EOF, transport close, fatal error).
+   */
+  private gracefulExit(code: number, reason: string): void {
+    if (this.isShuttingDown) return;
+    this.isShuttingDown = true;
+
+    logger.info(`Shutting down gracefully (${reason})...`);
+
+    Promise.resolve(this.shutdown())
+      .then(() => process.exit(code))
+      .catch(err => {
+        logger.error(`Error during shutdown (${reason}):`, err);
+        process.exit(code === 0 ? 1 : code);
+      });
   }
 
   /**
@@ -521,7 +522,15 @@ export class LocalLamaMcpServer {
                 }
                 case 'update_server': {
                   const updateResult = await runUpdate();
-                  return JSON.stringify(updateResult);
+                  // The new code is built but this process is still running the
+                  // old code. We do NOT self-exit (that would kill the client's
+                  // active MCP tools mid-session). Instead tell the client to
+                  // reconnect, which cleanly closes the transport -> graceful
+                  // shutdown (lock file released) -> respawn on the new build.
+                  const nextStep = updateResult.success
+                    ? 'Update built successfully. Run /mcp (reconnect locallama-dev) to graceful-restart onto the new build; no manual process kill is needed.'
+                    : 'Update did not complete; the server is still running the previous build.';
+                  return JSON.stringify({ ...updateResult, nextStep });
                 }
                 default:
                   logger.error(`Unknown tool: ${name}`);
@@ -581,46 +590,24 @@ export class LocalLamaMcpServer {
 
   async run(): Promise<void> {
     try {
-      // Check if another instance is already running
+      // This is a stdio MCP server: each MCP client (Claude Code, Cline, …)
+      // spawns and owns its own server process over a private stdio pipe. There
+      // is therefore no cross-process singleton — a new instance must always
+      // start and bind to the pipe its client just opened. The lock file is kept
+      // purely for diagnostics (records the most recent instance); if a stale
+      // lock from a terminated process is present we just log it.
       if (isLockFilePresent()) {
         const lockInfo: LockFileInfo | null = getLockFileInfo();
-        
-        // Check if the process in the lock file is still running
-        try {
-          const isProcessRunning = await import('./utils/lock-file.js').then(
-            module => module.isLockFileProcessRunning()
-          );
-          
-          if (isProcessRunning) {
-            // The other server instance is still running
-            logger.info(`Another instance of LocalLama MCP Server is already running.`);
-            logger.info(`Process: ${lockInfo?.pid || 'unknown'}, Started: ${lockInfo?.startTime || 'unknown'}`);
-            if (lockInfo?.connectionInfo) {
-              logger.info(`Connection Info: ${lockInfo.connectionInfo}`);
-            }
-            logger.info(`This process will exit and requests will be directed to the existing instance.`);
-            process.exit(0);
-            return;
-          } else {
-            // The lock file exists but the process is not running (stale lock file)
-            logger.info(`Found a stale lock file from a terminated server instance. Removing it.`);
-            removeLockFile();
-          }
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          logger.error('Error checking if lock file process is running:', errorMessage);
-          logger.error('Lock file details:', lockInfo);
-          throw error;
-        }
+        const stillRunning = isLockFileProcessRunning();
+        logger.info(
+          stillRunning
+            ? `Existing lock file from PID ${lockInfo?.pid ?? 'unknown'} (started ${lockInfo?.startTime ?? 'unknown'}); overwriting for this instance.`
+            : `Found a stale lock file from a terminated server instance; overwriting it.`
+        );
       }
-      
-      // No lock file or stale lock file was removed, continue starting the server
 
-      // Connection information for the lock file
-      const connectionInfo = `LocalLama MCP Server running on stdio`;
-
-      // Create lock file with current process info and connection details
-      createLockFile({ connectionInfo });
+      // Record this instance in the (diagnostic-only) lock file.
+      createLockFile({ connectionInfo: 'LocalLama MCP Server running on stdio' });
 
       // Bootstrap the provider registry before anything that needs to know which
       // providers exist (decision engine, tool listing). Provider init failures
@@ -728,6 +715,9 @@ export class LocalLamaMcpServer {
       
       logger.info('Starting LocalLama MCP Server...');
       const transport = new StdioServerTransport();
+      // The MCP transport closing is the canonical "client disconnected" signal.
+      // Mirror the stdin-EOF handler so we shut down instead of orphaning.
+      this.server.onclose = () => this.gracefulExit(0, 'MCP transport closed');
       await this.server.connect(transport);
 
       // Capture the connected client's name for per-client behavioral hints.

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,6 +246,14 @@ export class LocalLamaMcpServer {
       // Registry may not have been initialized; ignore.
     }
     try {
+      // Close the JobTracker WebSocket server (binds from port 8080) so the
+      // port is released cleanly rather than only on process exit.
+      const { shutdownJobTracker } = await import('./modules/decision-engine/services/jobTracker.js');
+      await shutdownJobTracker();
+    } catch {
+      // JobTracker may not have been initialized; ignore.
+    }
+    try {
       await this.server.close();
       logger.info('Server closed successfully');
     } catch (err) {

--- a/src/modules/api-integration/tool-definition/index.ts
+++ b/src/modules/api-integration/tool-definition/index.ts
@@ -612,7 +612,7 @@ class ToolDefinitionProvider implements IToolDefinitionProvider {
       },
       {
         name: 'update_server',
-        description: 'Pull the latest changes from GitHub and rebuild the server. Runs git pull, npm install, and npm run build in sequence. IMPORTANT: The server must be manually restarted after this completes for changes to take effect.',
+        description: 'Pull the latest changes from GitHub and rebuild the server. Runs git pull, npm install, and npm run build in sequence. The running process keeps serving the previous build until the client reconnects (e.g. /mcp), which triggers a graceful restart onto the new build — no manual process kill is required.',
         inputSchema: {
           type: 'object',
           properties: {},

--- a/src/utils/lock-file.js
+++ b/src/utils/lock-file.js
@@ -29,14 +29,13 @@ export function createLockFile(additionalInfo = {}) {
       ...additionalInfo
     };
 
-    fs.writeFileSync(getLockFilePath(), JSON.stringify(lockInfo), { flag: 'wx' });
+    // The lock file is diagnostic only: it records the most recent instance and
+    // never blocks a new stdio MCP instance from starting (each MCP client owns
+    // its own server over a private stdio pipe). Overwrite any existing file.
+    fs.writeFileSync(getLockFilePath(), JSON.stringify(lockInfo), { flag: 'w' });
   } catch (error) {
-    if (error.code === 'EEXIST') {
-      console.log('Lock file already exists.');
-    } else {
-      console.error('Error creating lock file:', error);
-    }
-    process.exit(1);
+    // A failed lock write must never prevent the server from running.
+    console.error('Error creating lock file (continuing without it):', error);
   }
 }
 
@@ -54,10 +53,13 @@ export function isLockFilePresent() {
 export function removeLockFile() {
   try {
     const lockFilePath = getLockFilePath();
-    if (fs.existsSync(lockFilePath)) {
-      fs.unlinkSync(lockFilePath);
-      console.log('Lock file removed.');
-    }
+    if (!fs.existsSync(lockFilePath)) return;
+    // Only remove the lock if it belongs to this process. Another live instance
+    // (a different MCP client session) may legitimately own it.
+    const info = getLockFileInfo();
+    if (info && info.pid && info.pid !== process.pid) return;
+    fs.unlinkSync(lockFilePath);
+    console.log('Lock file removed.');
   } catch (error) {
     console.error('Error removing lock file:', error);
   }

--- a/test/config/lock-contention.test.ts
+++ b/test/config/lock-contention.test.ts
@@ -34,25 +34,28 @@ afterEach(() => {
 });
 
 describe('lock file contention', () => {
-  it('calls process.exit(1) when createLockFile is called while a lock already exists', async () => {
+  it('overwrites an existing lock file without exiting (stdio MCP: no cross-process singleton)', async () => {
     const lockModule = await importFreshModule(
       path.resolve(originalCwd, 'dist/utils/lock-file.js'),
       `lock-contention-a=${Date.now()}`
     );
+    const lockPath = path.join(tempDir, 'locallama.lock');
 
-    // First call should create the lock file without error
-    lockModule.createLockFile({ port: 0 });
-    expect(fs.existsSync(path.join(tempDir, 'locallama.lock'))).toBe(true);
+    // Seed a lock file from a different (stale) instance.
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: 999999999, connectionInfo: 'stale' }));
 
-    // Mock process.exit so the test process doesn't actually exit
+    // process.exit must never be called: a new stdio instance must always start.
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(
       ((code?: number) => { throw new Error(`process.exit(${code}) called`); }) as typeof process.exit
     );
 
     try {
-      // Second call should fail — lock file already exists (EEXIST)
-      expect(() => lockModule.createLockFile({ port: 0 })).toThrow();
-      expect(exitSpy).toHaveBeenCalledWith(1);
+      // Second call should overwrite the existing lock with our own pid, not exit.
+      expect(() => lockModule.createLockFile({ connectionInfo: 'mine' })).not.toThrow();
+      expect(exitSpy).not.toHaveBeenCalled();
+      const info = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+      expect(info.pid).toBe(process.pid);
+      expect(info.connectionInfo).toBe('mine');
     } finally {
       exitSpy.mockRestore();
       lockModule.removeLockFile();
@@ -74,6 +77,33 @@ describe('lock file contention', () => {
     } finally {
       lockModule.removeLockFile();
     }
+  });
+
+  it('removeLockFile() leaves a lock owned by a different live process intact', async () => {
+    const lockModule = await importFreshModule(
+      path.resolve(originalCwd, 'dist/utils/lock-file.js'),
+      `lock-contention-own=${Date.now()}`
+    );
+    const lockPath = path.join(tempDir, 'locallama.lock');
+
+    // Lock owned by another live process (use the parent pid, guaranteed alive).
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: process.ppid, startTime: new Date().toISOString() }));
+
+    lockModule.removeLockFile();
+    expect(fs.existsSync(lockPath)).toBe(true); // not ours -> untouched
+  });
+
+  it('removeLockFile() removes a lock owned by the current process', async () => {
+    const lockModule = await importFreshModule(
+      path.resolve(originalCwd, 'dist/utils/lock-file.js'),
+      `lock-contention-own2=${Date.now()}`
+    );
+    const lockPath = path.join(tempDir, 'locallama.lock');
+
+    lockModule.createLockFile({ connectionInfo: 'mine' });
+    expect(fs.existsSync(lockPath)).toBe(true);
+    lockModule.removeLockFile();
+    expect(fs.existsSync(lockPath)).toBe(false);
   });
 
   it('isLockFileProcessRunning() returns false for a dead PID', async () => {

--- a/test/dispatcher.test.ts
+++ b/test/dispatcher.test.ts
@@ -83,6 +83,7 @@ jest.unstable_mockModule('../dist/modules/job-store/alert.js', () => ({
 
 jest.unstable_mockModule('../dist/utils/lock-file.js', () => ({
   isLockFilePresent: jest.fn().mockReturnValue(false),
+  isLockFileProcessRunning: jest.fn().mockReturnValue(false),
   getLockFileInfo: jest.fn().mockReturnValue(null),
   createLockFile: jest.fn(),
   removeLockFile: jest.fn(),


### PR DESCRIPTION
The `locallama-dev` MCP server could be orphaned when Claude Code closed, refuse to start a second session, and gave no graceful path to restart after an update. Three root causes, three fixes.

## 1. Orphan on client close
Only SIGINT/SIGTERM/SIGHUP were handled. A hard kill or crash of the parent sends **no signal** — stdin EOF is the only notice, and it was ignored. The JobTracker WebSocket server (bound from :8080) and other handles kept the event loop alive, so the process was reparented to init and lingered, holding the lock file and :8080.

- Handle stdin `end`/`close` and MCP transport `onclose` as shutdown triggers.
- Consolidated all shutdown paths into one idempotent `gracefulExit(code, reason)`.

## 2. "Something else starts it / not hooking into itself"
The startup did a cross-process singleton check: if a live lock existed, `process.exit(0)`. Wrong for stdio MCP — each client owns its own server over a private stdio pipe. A second session's server exited immediately, leaving that session with a dead MCP server while the orphan kept the lock.

- Removed the singleton-exit. A new instance always starts.
- Lock file is now diagnostic-only: `createLockFile` overwrites (`flag: 'w'`) and never exits; `removeLockFile` only deletes a lock owned by the current PID.

## 3. No graceful update→restart
`update_server` pulled/built then said "manually restart"; the old process kept running old code and holding the lock.

- `update_server` now returns a `nextStep`: reconnect (`/mcp`) → transport close → graceful shutdown (lock released) → respawn on the new build. No manual kill. Tool description updated to match.

## Clean :8080 release
The JobTracker starts a persistent `WebSocketServer` bound from port 8080. The server `shutdown()` closed providers and the MCP server but never the JobTracker, so :8080 was only freed by the eventual `process.exit()`. Added `shutdownJobTracker()` to the graceful shutdown so the WS server and its clients close cleanly before exit.

(`ws-server.ts`, a separate express :3001 / ws :4000 module, is not wired into the running server path — no change needed.)

## Tests
454 pass. Rewrote `lock-contention` expectations for overwrite semantics, added ownership-safe `removeLockFile` coverage, and added the new export to the dispatcher lock-file mock.

Note: 2 `findFreePort` tests in `test/modules/llama-cpp/manager.test.ts` fail locally because they bind the real port :8080, which a running `locallama-dev` instance (JobTracker WS) already holds. Pre-existing and environmental, unrelated to this change — but they highlight that those tests should use an ephemeral port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)