### PR TITLE
Fix free-tier trio ranking

### DIFF
--- a/docs/history/memory-bank/sessionLog.md
+++ b/docs/history/memory-bank/sessionLog.md
@@ -139,3 +139,20 @@ Verification:
 
 Follow-ups:
 - Full live OpenRouter benchmarking was not run in this pass to avoid paid/free-provider side effects; use an explicit operational run when provider credentials and rate budget are available.
+
+## 2026-06-02 - Issue #111 Free-tier Trio Ranking
+
+Author: Codex
+
+Summary:
+- Updated free-tier ranked trio scoring to read benchmark summaries from `ModelRegistry` instead of the legacy `modelsDb` path.
+- Added OpenRouter upstream-provider diversity scoring so retries prefer a different free-model upstream when scores are close.
+- Added a recent rate-limit penalty using OpenRouter free-model health state so recently rate-limited candidates drop in the trio.
+- Normalized `preemptive_route_task` provider metadata so free OpenRouter models report `providerId: openrouter` and `costClass: free`.
+
+Verification:
+- Focused Jest run passes: `npm test -- --runInBand test/modules/api-integration/routing/index.test.ts`.
+- Full Jest run passes unsandboxed: `npm test` (61 suites / 460 tests).
+
+Follow-ups:
+- Full live OpenRouter validation was not run in this pass to avoid remote-provider side effects.

--- a/src/modules/api-integration/routing/index.ts
+++ b/src/modules/api-integration/routing/index.ts
@@ -27,6 +27,7 @@ import { Model } from '../../../types/index.js'; // Import Model type
 import { getModelRegistry } from '../../core/model/index.js';
 import { countTokens } from '../../utils/tokenCount.js';
 import { ContextWindowError } from '../../utils/contextWindow.js';
+import { openRouterModule } from '../../openrouter/index.js';
 import {
   cancelJobsForTask,
   getTask,
@@ -39,9 +40,9 @@ import {
 import { refreshAlertState } from '../../job-store/alert.js';
 import type { JobStatus as PersistedJobStatus, TaskStatus as PersistedTaskStatus } from '../../job-store/types.js';
 import { COMPLEXITY_THRESHOLDS } from '../../decision-engine/types/index.js';
-import { modelsDbService } from '../../decision-engine/services/modelsDb.js';
 
 const CODE_TASK_PATTERN = /\b(code|function|class|implement|debug|test|refactor|fix|bug|method|module|api|script|parse|algorithm|compile)\b/i;
+const RECENT_RATE_LIMIT_WINDOW_MS = 5 * 60 * 1000;
 
 let jobTracker: Awaited<ReturnType<typeof getJobTracker>>;
 
@@ -218,6 +219,51 @@ export class Router implements IRouter {
     }
   }
 
+  private normalizeOpenRouterModelId(modelId: string): string {
+    return modelId.startsWith('openrouter:') ? modelId.substring('openrouter:'.length) : modelId;
+  }
+
+  private getFreeTierUpstreamProvider(modelId: string): string {
+    const normalizedModelId = this.normalizeOpenRouterModelId(modelId);
+    return (
+      openRouterModule.modelTracking.models[normalizedModelId]?.provider ||
+      openRouterModule.getProviderFromModelId(normalizedModelId)
+    );
+  }
+
+  private getRegistryBenchmarkScore(modelId: string, taskCategory?: string): number | undefined {
+    const benchmarkSummary = getModelRegistry().getModel(modelId)?.benchmarkSummary;
+    if (!benchmarkSummary) return undefined;
+
+    const successRate = benchmarkSummary.successRate ?? 0;
+    const categoryScores = benchmarkSummary.scores as Record<string, number | undefined> | undefined;
+    const qualitySignal = (taskCategory ? categoryScores?.[taskCategory] : undefined) ?? benchmarkSummary.qualityScore ?? 0;
+    const avgResponseTime = benchmarkSummary.avgResponseTime ?? 0;
+    const responseTimeFactor = Math.max(0, 1 - (avgResponseTime / 15000));
+    const empiricalScore = successRate * 0.3 + qualitySignal * 0.5 + responseTimeFactor * 0.2;
+    const confidence = Math.min(1, (benchmarkSummary.benchmarkCount ?? 0) / 3);
+
+    return empiricalScore * confidence;
+  }
+
+  private getRecentFreeTierRateLimitPenalty(modelId: string): number {
+    const normalizedModelId = this.normalizeOpenRouterModelId(modelId);
+    const health = openRouterModule.modelTracking.freeModelHealth?.[normalizedModelId];
+    if (!health) return 0;
+
+    const failurePenalty = Math.min(0.15, (health.consecutiveFailures ?? 0) * 0.05);
+    if (health.lastErrorType !== 'rate_limit' || !health.lastFailureAt) {
+      return failurePenalty;
+    }
+
+    const lastFailureTime = new Date(health.lastFailureAt).getTime();
+    if (!Number.isFinite(lastFailureTime)) return failurePenalty;
+
+    return Date.now() - lastFailureTime <= RECENT_RATE_LIMIT_WINDOW_MS
+      ? failurePenalty + 0.3
+      : failurePenalty;
+  }
+
   private async buildRankedTrio(
     selectedModelId: string,
     tier: 'local' | 'free' | 'paid',
@@ -322,22 +368,9 @@ export class Router implements IRouter {
           }
         }
       } else if (tier === 'free') {
-        const modelsDb = modelsDbService.getDatabase();
-        const modelData = modelsDb?.models?.[model.id] as any;
-        if (modelData && modelData.benchmarkCount > 0) {
-          const successRateWeight = 0.4;
-          const qualityScoreWeight = 0.4;
-          const responseTimeWeight = 0.2;
-          const complexityMatchWeight = 0.1;
-          score += modelData.successRate * successRateWeight;
-          score += modelData.qualityScore * qualityScoreWeight;
-          const responseTimeFactor = Math.max(0, 1 - (modelData.avgResponseTime / 15000));
-          score += responseTimeFactor * responseTimeWeight;
-          const complexityMatchFactor = 1 - Math.abs(modelData.complexityScore - complexity);
-          score += complexityMatchFactor * complexityMatchWeight;
-          if (modelData.benchmarkCount >= 3) {
-            score += 0.1;
-          }
+        const registryScore = this.getRegistryBenchmarkScore(model.id, taskCategory);
+        if (registryScore !== undefined) {
+          score += registryScore;
         } else {
           score += 0.3;
           if (model.id.toLowerCase().includes('instruct')) {
@@ -357,6 +390,12 @@ export class Router implements IRouter {
             score += 0.2;
           }
         }
+        const selectedUpstreamProvider = this.getFreeTierUpstreamProvider(selectedModelId);
+        const candidateUpstreamProvider = this.getFreeTierUpstreamProvider(model.id);
+        if (candidateUpstreamProvider !== selectedUpstreamProvider) {
+          score += 0.08;
+        }
+        score -= this.getRecentFreeTierRateLimitPenalty(model.id);
       } else {
         const benchmarkSummary = getModelRegistry().getModel(model.id)?.benchmarkSummary;
         if (benchmarkSummary) {
@@ -880,9 +919,9 @@ export class Router implements IRouter {
       // Return a routing recommendation — actual execution happens via route_task
       return {
         model: decision.model,
-        providerId: decision.provider,
-        costClass: providerCostClass(decision.provider),
-        provider: decision.provider,
+        providerId,
+        costClass: tier,
+        provider: providerId,
         reason: `Preemptive routing selected ${decision.model} (${decision.provider}). Call route_task to execute. ${routingReason}`,
         resultCode: '',
         details: {},

--- a/test/modules/api-integration/routing/index.test.ts
+++ b/test/modules/api-integration/routing/index.test.ts
@@ -19,8 +19,7 @@ jest.unstable_mockModule('../../../../dist/config/index.js', () => ({
   },
 }));
 
-const mockGetModelRegistry = jest.fn().mockReturnValue({
-  getModel: jest.fn().mockImplementation((modelId) => {
+const mockRegistryGetModel = jest.fn().mockImplementation((modelId) => {
     if (modelId === 'qwen2.5-coder:7b') {
       return {
         id: 'qwen2.5-coder:7b',
@@ -46,7 +45,10 @@ const mockGetModelRegistry = jest.fn().mockReturnValue({
       };
     }
     return undefined;
-  }),
+  });
+
+const mockGetModelRegistry = jest.fn().mockReturnValue({
+  getModel: mockRegistryGetModel,
   listAll: jest.fn().mockReturnValue([
     { id: 'qwen2.5-coder:7b', contextWindow: 8000 },
     { id: 'llama3:8b', contextWindow: 8000 },
@@ -56,6 +58,20 @@ const mockGetModelRegistry = jest.fn().mockReturnValue({
 
 jest.unstable_mockModule('../../../../dist/modules/core/model/index.js', () => ({
   getModelRegistry: mockGetModelRegistry,
+}));
+
+const mockOpenRouterModelTracking = {
+  models: {},
+  lastUpdated: new Date().toISOString(),
+  freeModels: [],
+  freeModelHealth: {},
+};
+
+jest.unstable_mockModule('../../../../dist/modules/openrouter/index.js', () => ({
+  openRouterModule: {
+    modelTracking: mockOpenRouterModelTracking,
+    getProviderFromModelId: jest.fn((modelId: string) => modelId.split('/')[0] || 'unknown'),
+  },
 }));
 
 const mockRouteTaskDecision = jest.fn().mockResolvedValue({
@@ -202,6 +218,36 @@ describe('api-integration routing', () => {
     mockGetQueuePositionForJob.mockResolvedValue(1);
     mockCancelJobsForTask.mockResolvedValue(0);
     mockGetAvailableModels.mockResolvedValue([]);
+    mockRegistryGetModel.mockImplementation((modelId) => {
+      if (modelId === 'qwen2.5-coder:7b') {
+        return {
+          id: 'qwen2.5-coder:7b',
+          providerId: 'ollama',
+          displayName: 'Qwen 2.5 Coder 7B',
+          benchmarkSummary: { benchmarkCount: 5, successRate: 0.8, qualityScore: 0.85, avgResponseTime: 2000, scores: { code: 0.9 } },
+        };
+      }
+      if (modelId === 'llama3:8b') {
+        return {
+          id: 'llama3:8b',
+          providerId: 'ollama',
+          displayName: 'Llama 3 8B',
+          benchmarkSummary: { benchmarkCount: 2, successRate: 0.6, qualityScore: 0.7, avgResponseTime: 3000, scores: { code: 0.75 } },
+        };
+      }
+      if (modelId === 'phi3:3.8b') {
+        return {
+          id: 'phi3:3.8b',
+          providerId: 'ollama',
+          displayName: 'Phi 3 3.8B',
+          benchmarkSummary: { benchmarkCount: 0, successRate: 0, qualityScore: 0, avgResponseTime: 0 },
+        };
+      }
+      return undefined;
+    });
+    mockOpenRouterModelTracking.models = {};
+    mockOpenRouterModelTracking.freeModels = [];
+    mockOpenRouterModelTracking.freeModelHealth = {};
     mockRegistry.list.mockReturnValue([mockOpenRouterProvider]);
     mockRegistry.has.mockImplementation((providerId: string) => providerId === 'openrouter' || providerId === 'ollama' || providerId === 'lm-studio');
     mockRegistry.isAvailable.mockImplementation((providerId: string) => providerId !== 'ollama' && providerId !== 'lm-studio');
@@ -728,7 +774,7 @@ describe('api-integration routing', () => {
       priority: 'cost',
     });
 
-    expect(result.providerId).toBe('paid');
+    expect(result.providerId).toBe('openrouter');
     expect(result.costClass).toBe('paid');
     expect(result.model).toBe('openai/gpt-4o-mini');
   });
@@ -819,6 +865,72 @@ describe('api-integration routing', () => {
       expect(result.ranked_trio?.good.model_id).toBe('qwen2.5-coder:7b');
       expect(result.ranked_trio?.better.model_id).toBe('llama3:8b');
       expect(result.ranked_trio?.best.model_id).toBe('phi3:3.8b');
+    });
+
+    it('ranks free-tier trio candidates from ModelRegistry with diversity and rate-limit factors', async () => {
+      const { decisionEngine } = await import('../../../../dist/modules/decision-engine/index.js');
+      (decisionEngine.preemptiveRouting as jest.Mock).mockResolvedValueOnce({
+        provider: 'paid',
+        model: 'alpha/good-free:free',
+        explanation: 'Free-tier route decision.',
+      });
+
+      mockGetAvailableModels.mockResolvedValue([
+        { id: 'alpha/good-free:free', name: 'Alpha Good', provider: 'openrouter', contextWindow: 8000, costPerToken: { prompt: 0, completion: 0 } },
+        { id: 'alpha/high-score-free:free', name: 'Alpha High Score', provider: 'openrouter', contextWindow: 8000, costPerToken: { prompt: 0, completion: 0 } },
+        { id: 'beta/diverse-free:free', name: 'Beta Diverse', provider: 'openrouter', contextWindow: 8000, costPerToken: { prompt: 0, completion: 0 } },
+        { id: 'gamma/rate-limited-free:free', name: 'Gamma Rate Limited', provider: 'openrouter', contextWindow: 8000, costPerToken: { prompt: 0, completion: 0 } },
+      ]);
+      mockGetFreeModels.mockResolvedValue([
+        { id: 'alpha/good-free:free' },
+        { id: 'alpha/high-score-free:free' },
+        { id: 'beta/diverse-free:free' },
+        { id: 'gamma/rate-limited-free:free' },
+      ]);
+      mockRegistryGetModel.mockImplementation((modelId) => {
+        const scores: Record<string, number> = {
+          'alpha/good-free:free': 0.78,
+          'alpha/high-score-free:free': 0.95,
+          'beta/diverse-free:free': 0.92,
+          'gamma/rate-limited-free:free': 0.99,
+        };
+        return {
+          id: modelId,
+          providerId: 'openrouter',
+          benchmarkSummary: {
+            benchmarkCount: 5,
+            successRate: 1,
+            qualityScore: scores[modelId] ?? 0,
+            avgResponseTime: 1000,
+            scores: { code: scores[modelId] ?? 0 },
+          },
+        };
+      });
+      mockOpenRouterModelTracking.models = {
+        'alpha/good-free:free': { provider: 'alpha' },
+        'alpha/high-score-free:free': { provider: 'alpha' },
+        'beta/diverse-free:free': { provider: 'beta' },
+        'gamma/rate-limited-free:free': { provider: 'gamma' },
+      };
+      mockOpenRouterModelTracking.freeModelHealth = {
+        'gamma/rate-limited-free:free': {
+          consecutiveFailures: 1,
+          lastErrorType: 'rate_limit',
+          lastFailureAt: new Date().toISOString(),
+        },
+      };
+
+      const result = await preemptiveRouteTask({
+        task: 'Write a TypeScript parser.',
+        contextLength: 100,
+        complexity: 0.5,
+        priority: 'quality',
+      });
+
+      expect(result.costClass).toBe('free');
+      expect(result.ranked_trio?.good.model_id).toBe('alpha/good-free:free');
+      expect(result.ranked_trio?.better.model_id).toBe('beta/diverse-free:free');
+      expect(result.ranked_trio?.best.model_id).toBe('alpha/high-score-free:free');
     });
   });
 });


### PR DESCRIPTION
Closes #111

## Summary
- Route free-tier trio benchmark scoring through ModelRegistry instead of legacy modelsDb.
- Add OpenRouter upstream-provider diversity bonus for fallback trio candidates.
- Penalize recently rate-limited free-tier models using OpenRouter free-model health.
- Normalize preemptive free OpenRouter responses to providerId=openrouter and costClass=free.

## Tests
- npm test -- --runInBand test/modules/api-integration/routing/index.test.ts
- npm test (unsandboxed; 61 suites / 460 tests)