### PR TITLE
[codex] Introduce validation scoring primitives

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ BENCHMARK_MAX_PARALLEL_TASKS=2
 BENCHMARK_TASK_TIMEOUT=60000
 BENCHMARK_SAVE_RESULTS=true
 BENCHMARK_RESULTS_PATH=./benchmark-results
+RELIABLE_BENCHMARK_COUNT=3
+MIN_VALIDATOR_SCORE=0.6
+VALIDATION_RETRY_BUDGET=1
 # STARTUP_BENCHMARK_TARGETS: Comma-separated list of model types to benchmark on startup.
 # Options: local, free, paid, all, none. Default depends on OPENROUTER_API_KEY (free if set, local otherwise).
 # Example: STARTUP_BENCHMARK_TARGETS=local,free

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ BENCHMARK_MAX_PARALLEL_TASKS=2
 BENCHMARK_TASK_TIMEOUT=60000
 BENCHMARK_SAVE_RESULTS=true
 BENCHMARK_RESULTS_PATH=./benchmark-results
+RELIABLE_BENCHMARK_COUNT=3
+MIN_VALIDATOR_SCORE=0.6
+VALIDATION_RETRY_BUDGET=1
 
 # Lock file
 LOCK_FILE_CHECK_ACTIVE_PROCESS=true
@@ -99,6 +102,9 @@ LOG_LEVEL=debug
 | `TOKEN_THRESHOLD` | `1500` | Token count above which local offload is considered |
 | `COST_THRESHOLD` | `0.02` | USD cost above which local offload is preferred |
 | `QUALITY_THRESHOLD` | `0.7` | Quality score below which paid API is always used |
+| `RELIABLE_BENCHMARK_COUNT` | `3` | Benchmark runs required before empirical scores are treated as fully reliable |
+| `MIN_VALIDATOR_SCORE` | `0.6` | Minimum validation score required before a model is eligible for external validation |
+| `VALIDATION_RETRY_BUDGET` | `1` | Validation retry attempts allowed after an initial failed validation |
 | `PROVIDER_MAX_CONCURRENT_LOCAL` | `1` | Shared local execution slot count |
 | `PROVIDER_MAX_CONCURRENT_REMOTE` | `5` | Per-remote-provider slot count |
 | `OPENROUTER_API_KEY` | — | Enables OpenRouter provider and related tools |

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -417,7 +417,7 @@ The detector lives in `src/modules/core/capability/detector.ts`. It is called by
 
 ### Design
 
-- New `benchmark_model` MCP tool (added to [tool-definition/index.ts](src/modules/api-integration/tool-definition/index.ts) + dispatcher in [src/index.ts](src/index.ts)) takes `{ modelId, taskCategories?: ['code','chat','tool-use','long-context'] }` and runs the matching benchmark suites against that model **via the provider abstraction**.
+- New `benchmark_model` MCP tool (added to [tool-definition/index.ts](src/modules/api-integration/tool-definition/index.ts) + dispatcher in [src/index.ts](src/index.ts)) takes `{ modelId, taskCategories?: ['code','chat','tool-use','long-context','validate'] }` and runs the matching benchmark suites against that model **via the provider abstraction**.
 - Results flow into `ModelRegistry.updateBenchmarkSummary` and persist to the existing `data/benchmarks.db` (via [benchmark/storage/benchmarkDb.ts](src/modules/benchmark/storage/benchmarkDb.ts)).
 - Existing `benchmark_task`, `benchmark_tasks`, and `benchmark_free_models` tools continue to work but use the provider abstraction internally — drop the hardcoded `provider === 'lm-studio'` / `'ollama'` branches in [benchmark/core/runner.ts:81-93](src/modules/benchmark/core/runner.ts#L81-L93).
 - Startup benchmark (`STARTUP_BENCHMARK_TARGETS`) iterates providers by `costClass` instead of name, so adding a new "local" provider Just Works.
@@ -1367,5 +1367,4 @@ The webapp is explicitly single-developer-at-a-time, localhost-only. Scalability
 - How are errors distinguished from expected "routing decided local" responses? The UI must differentiate tool-level errors (MCP error codes) from application-level decisions (model selected, cost estimated).
 - Benchmark results are opaque numbers without context. A "compare to baseline" feature (pin a result, then re-run to see delta) would make benchmarks actionable.
 - The webapp should surface the OPERATIONAL_TEST_PLAN.md's suite structure (smoke / routing / LLM) as pre-built test sequences, not just raw tool invocations. Users unfamiliar with the server's tool surface should be able to run a smoke check with one click.
-
 

--- a/docs/history/memory-bank/sessionLog.md
+++ b/docs/history/memory-bank/sessionLog.md
@@ -156,3 +156,20 @@ Verification:
 
 Follow-ups:
 - Full live OpenRouter validation was not run in this pass to avoid remote-provider side effects.
+
+## 2026-06-02 - Issue #112 Validation Scoring Primitives
+
+Author: Codex
+
+Summary:
+- Added `validate` as a first-class `benchmark_model` task category and MCP schema option.
+- Added binary validation fixtures that score first-line YES/NO verdicts and persist `summary.scores.validate`.
+- Added seeded validation-score behavior: when real validate scores are absent, validation scoring derives `scores.code * 0.8` and treats it as one confidence-discounted run.
+- Exposed shared config gates `RELIABLE_BENCHMARK_COUNT`, `MIN_VALIDATOR_SCORE`, and `VALIDATION_RETRY_BUDGET` with defaults documented in README and `.env.example`.
+
+Verification:
+- Focused Jest run passes: `npm test -- --runTestsByPath test/modules/benchmark/model-benchmarker.test.ts test/config/startup-benchmark-defaults.test.ts test/modules/decision-engine/modelSelector.task-category.test.ts`.
+- Full Jest run passes: `npm test` (61 suites / 464 tests). Jest still prints the existing forced-worker-exit warning after completion.
+
+Follow-ups:
+- Full external validator selection and validation retry loops remain future work from `docs/PRD-validator-benchmarking.md`.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -69,6 +69,9 @@ export interface Config {
   costThreshold: number;
   qualityThreshold: number;
   codeScoreThreshold: number;
+  reliableBenchmarkCount: number;
+  minValidatorScore: number;
+  validationRetryBudget: number;
 
   // API Keys
   openRouterApiKey?: string;
@@ -124,6 +127,9 @@ export const HOT_RELOADABLE_CONFIG_FIELDS = [
   'costThreshold',
   'qualityThreshold',
   'codeScoreThreshold',
+  'reliableBenchmarkCount',
+  'minValidatorScore',
+  'validationRetryBudget',
   'openRouterFreeOnly',
   'openRouterRateLimitPerMinute',
   'providerTimeoutMs',
@@ -179,6 +185,9 @@ export interface ReloadConfigResult {
     costThreshold: number;
     qualityThreshold: number;
     codeScoreThreshold: number;
+    reliableBenchmarkCount: number;
+    minValidatorScore: number;
+    validationRetryBudget: number;
     openRouterFreeOnly: boolean;
     openRouterRateLimitPerMinute: number;
     providerTimeoutMs: number;
@@ -266,6 +275,9 @@ function buildConfigFromEnv(env: NodeJS.ProcessEnv): Config {
     costThreshold: parseFloat(env.COST_THRESHOLD || '0.02'),
     qualityThreshold: parseFloat(env.QUALITY_THRESHOLD || '0.7'),
     codeScoreThreshold: parseNumber(env.CODE_SCORE_THRESHOLD, 0.3),
+    reliableBenchmarkCount: Math.round(parseNumber(env.RELIABLE_BENCHMARK_COUNT, 3, 1)),
+    minValidatorScore: parseNumber(env.MIN_VALIDATOR_SCORE, 0.6, 0, 1),
+    validationRetryBudget: Math.round(parseNumber(env.VALIDATION_RETRY_BUDGET, 1, 0)),
 
     // API Keys
     openRouterApiKey: env.OPENROUTER_API_KEY,
@@ -327,6 +339,9 @@ function getActiveHotReloadSnapshot(cfg: Config): ReloadConfigResult['activeConf
     costThreshold: cfg.costThreshold,
     qualityThreshold: cfg.qualityThreshold,
     codeScoreThreshold: cfg.codeScoreThreshold,
+    reliableBenchmarkCount: cfg.reliableBenchmarkCount,
+    minValidatorScore: cfg.minValidatorScore,
+    validationRetryBudget: cfg.validationRetryBudget,
     openRouterFreeOnly: cfg.openRouterFreeOnly,
     openRouterRateLimitPerMinute: cfg.openRouterRateLimitPerMinute,
     providerTimeoutMs: cfg.providerTimeoutMs,
@@ -355,6 +370,9 @@ function applyHotReloadableFields(target: Config, source: Config): void {
   target.costThreshold = source.costThreshold;
   target.qualityThreshold = source.qualityThreshold;
   target.codeScoreThreshold = source.codeScoreThreshold;
+  target.reliableBenchmarkCount = source.reliableBenchmarkCount;
+  target.minValidatorScore = source.minValidatorScore;
+  target.validationRetryBudget = source.validationRetryBudget;
   target.openRouterFreeOnly = source.openRouterFreeOnly;
   target.openRouterRateLimitPerMinute = source.openRouterRateLimitPerMinute;
   target.providerTimeoutMs = source.providerTimeoutMs;
@@ -411,6 +429,15 @@ function validateConfigValues(cfg: Config): void {
   }
   if (cfg.codeScoreThreshold < 0 || cfg.codeScoreThreshold > 1) {
     errors.push(`Invalid codeScoreThreshold: ${cfg.codeScoreThreshold}`);
+  }
+  if (cfg.reliableBenchmarkCount <= 0) {
+    errors.push(`Invalid reliableBenchmarkCount: ${cfg.reliableBenchmarkCount}`);
+  }
+  if (cfg.minValidatorScore < 0 || cfg.minValidatorScore > 1) {
+    errors.push(`Invalid minValidatorScore: ${cfg.minValidatorScore}`);
+  }
+  if (cfg.validationRetryBudget < 0) {
+    errors.push(`Invalid validationRetryBudget: ${cfg.validationRetryBudget}`);
   }
   // Validate model config
   const { temperature, topP, maxTokens } = cfg.defaultModelConfig;

--- a/src/modules/api-integration/routing/index.ts
+++ b/src/modules/api-integration/routing/index.ts
@@ -237,11 +237,17 @@ export class Router implements IRouter {
 
     const successRate = benchmarkSummary.successRate ?? 0;
     const categoryScores = benchmarkSummary.scores as Record<string, number | undefined> | undefined;
-    const qualitySignal = (taskCategory ? categoryScores?.[taskCategory] : undefined) ?? benchmarkSummary.qualityScore ?? 0;
+    const taskCategoryScore = taskCategory === 'validate' && categoryScores?.validate === undefined
+      ? (categoryScores?.code === undefined ? undefined : categoryScores.code * 0.8)
+      : (taskCategory ? categoryScores?.[taskCategory] : undefined);
+    const qualitySignal = taskCategoryScore ?? benchmarkSummary.qualityScore ?? 0;
     const avgResponseTime = benchmarkSummary.avgResponseTime ?? 0;
     const responseTimeFactor = Math.max(0, 1 - (avgResponseTime / 15000));
     const empiricalScore = successRate * 0.3 + qualitySignal * 0.5 + responseTimeFactor * 0.2;
-    const confidence = Math.min(1, (benchmarkSummary.benchmarkCount ?? 0) / 3);
+    const benchmarkCount = taskCategory === 'validate' && categoryScores?.validate === undefined && categoryScores?.code !== undefined
+      ? 1
+      : benchmarkSummary.benchmarkCount ?? 0;
+    const confidence = Math.min(1, benchmarkCount / config.reliableBenchmarkCount);
 
     return empiricalScore * confidence;
   }
@@ -311,13 +317,16 @@ export class Router implements IRouter {
           if (taskCategory === 'code') taskCategoryScore = scores?.code;
           else if (taskCategory === 'reasoning') taskCategoryScore = scores?.reasoning;
           else if (taskCategory === 'speed') taskCategoryScore = scores?.speed;
+          else if (taskCategory === 'validate') taskCategoryScore = scores?.validate ?? (scores?.code === undefined ? undefined : scores.code * 0.8);
           
           const qualitySignal = taskCategoryScore ?? (benchmarkSummary.qualityScore ?? 0);
           const avgResponseTime = benchmarkSummary.avgResponseTime ?? 0;
           const responseTimeFactor = Math.max(0, 1 - (avgResponseTime / 15000));
           const empiricalScore = successRate * 0.3 + qualitySignal * 0.4 + responseTimeFactor * 0.3;
-          const benchmarkCount = benchmarkSummary.benchmarkCount ?? 1;
-          const confidence = Math.min(1, benchmarkCount / 3);
+          const benchmarkCount = taskCategory === 'validate' && scores?.validate === undefined && scores?.code !== undefined
+            ? 1
+            : benchmarkSummary.benchmarkCount ?? 1;
+          const confidence = Math.min(1, benchmarkCount / config.reliableBenchmarkCount);
           
           let heuristicScore = 0.30;
           const normalizedId = model.id.toLowerCase()

--- a/src/modules/api-integration/tool-definition/index.ts
+++ b/src/modules/api-integration/tool-definition/index.ts
@@ -362,7 +362,7 @@ class ToolDefinitionProvider implements IToolDefinitionProvider {
               type: 'array',
               items: {
                 type: 'string',
-                enum: ['code', 'chat', 'tool-use', 'long-context']
+                enum: ['code', 'chat', 'tool-use', 'long-context', 'validate']
               },
               description: 'Which task categories to run. Defaults to ["code", "chat"] when omitted.'
             }

--- a/src/modules/benchmark/core/model-benchmarker.ts
+++ b/src/modules/benchmark/core/model-benchmarker.ts
@@ -19,13 +19,14 @@ import { logger } from '../../../utils/logger.js';
 // Task category definitions
 // ---------------------------------------------------------------------------
 
-export type TaskCategory = 'code' | 'chat' | 'tool-use' | 'long-context';
+export type TaskCategory = 'code' | 'chat' | 'tool-use' | 'long-context' | 'validate';
 
 interface CategoryTask {
   task: string;
   contextLength: number;
   expectedOutputLength: number;
   complexity: number;
+  expectedVerdict?: 'YES' | 'NO';
 }
 
 /**
@@ -76,6 +77,30 @@ const CATEGORY_TASKS: Record<TaskCategory, CategoryTask[]> = {
       contextLength: 500,
       expectedOutputLength: 400,
       complexity: 0.6,
+    },
+  ],
+  validate: [
+    {
+      task: [
+        'You are validating a coding-agent answer. Return YES on the first line if the answer satisfies the task, otherwise return NO.',
+        'Task: Write a TypeScript add(a, b) function that returns the sum.',
+        'Answer: function add(a: number, b: number): number { return a + b; }',
+      ].join('\n'),
+      contextLength: 140,
+      expectedOutputLength: 8,
+      complexity: 0.3,
+      expectedVerdict: 'YES',
+    },
+    {
+      task: [
+        'You are validating a coding-agent answer. Return YES on the first line if the answer satisfies the task, otherwise return NO.',
+        'Task: Write a TypeScript add(a, b) function that returns the sum.',
+        'Answer: function add(a: number, b: number): number { return a - b; }',
+      ].join('\n'),
+      contextLength: 140,
+      expectedOutputLength: 8,
+      complexity: 0.3,
+      expectedVerdict: 'NO',
     },
   ],
 };
@@ -167,6 +192,12 @@ async function resolveExecutableModelId(
   }
 
   return requestedModelId;
+}
+
+function scoreValidationVerdict(output: string, expectedVerdict: 'YES' | 'NO'): number {
+  const firstLine = output.trim().split(/\r?\n/, 1)[0]?.trim().toUpperCase() ?? '';
+  const verdict = firstLine.startsWith('YES') ? 'YES' : firstLine.startsWith('NO') ? 'NO' : undefined;
+  return verdict === expectedVerdict ? 1 : 0;
 }
 
 /**
@@ -285,7 +316,9 @@ export async function benchmarkModel(
           { workload: 'benchmark', priority: 'background' },
         );
         const elapsed = Date.now() - startMs;
-        const quality = evaluateQuality(benchTask.task, execResult.content);
+        const quality = benchTask.expectedVerdict
+          ? scoreValidationVerdict(execResult.content, benchTask.expectedVerdict)
+          : evaluateQuality(benchTask.task, execResult.content);
 
         totalSuccess++;
         totalQuality += quality;
@@ -397,6 +430,7 @@ export async function benchmarkModel(
       code: categoryResults['code']?.qualityScore,
       reasoning: categoryResults['chat']?.qualityScore,
       speed: speedScore,
+      validate: categoryResults['validate']?.qualityScore,
     },
     successRate: overallSuccessRate,
     qualityScore: overallQuality,

--- a/src/modules/decision-engine/services/modelSelector.ts
+++ b/src/modules/decision-engine/services/modelSelector.ts
@@ -8,8 +8,14 @@ import { COMPLEXITY_THRESHOLDS } from '../types/index.js';
 import { isOpenRouterConfigured } from '../../api-integration/tool-definition/index.js';
 import { isProviderLocal } from '../../core/provider/index.js';
 import { getModelRegistry } from '../../core/model/index.js';
+import { config } from '../../../config/index.js';
 
-function getTaskCategoryScore(modelId: string, taskCategory?: string): number | undefined {
+interface TaskCategorySignal {
+  score: number;
+  seeded: boolean;
+}
+
+function getTaskCategorySignal(modelId: string, taskCategory?: string): TaskCategorySignal | undefined {
   if (!taskCategory) return undefined;
 
   const scores = getModelRegistry().getModel(modelId)?.benchmarkSummary?.scores;
@@ -17,11 +23,19 @@ function getTaskCategoryScore(modelId: string, taskCategory?: string): number | 
 
   switch (taskCategory) {
     case 'code':
-      return scores.code;
+      return scores.code === undefined ? undefined : { score: scores.code, seeded: false };
     case 'reasoning':
-      return scores.reasoning;
+      return scores.reasoning === undefined ? undefined : { score: scores.reasoning, seeded: false };
     case 'speed':
-      return scores.speed;
+      return scores.speed === undefined ? undefined : { score: scores.speed, seeded: false };
+    case 'validate':
+      if (scores.validate !== undefined) {
+        return { score: scores.validate, seeded: false };
+      }
+      if (scores.code !== undefined) {
+        return { score: scores.code * 0.8, seeded: true };
+      }
+      return undefined;
     default:
       return undefined;
   }
@@ -126,10 +140,6 @@ export const modelSelector = {
         return null;
       }
 
-      // Number of benchmark runs required before empirical data is treated as
-      // fully reliable. Below this, scores are blended with the size heuristic.
-      const RELIABLE_BENCHMARK_COUNT = 3;
-
       let bestModel: Model | null = null;
       let bestScore = 0;
 
@@ -144,7 +154,8 @@ export const modelSelector = {
 
           // Prefer task-category benchmark score when available (e.g. code score
           // for a code task); fall back to the overall quality score.
-          const taskCategoryScore = getTaskCategoryScore(model.id, taskCategory);
+          const taskCategorySignal = getTaskCategorySignal(model.id, taskCategory);
+          const taskCategoryScore = taskCategorySignal?.score;
           const qualitySignal = taskCategoryScore ?? (benchmarkSummary.qualityScore ?? 0);
 
           const avgResponseTime = benchmarkSummary.avgResponseTime ?? 0;
@@ -160,8 +171,8 @@ export const modelSelector = {
           // A single run on a small model can produce numbers that outclass a
           // large model, but may not be representative. Blend with the
           // size-based heuristic until we have enough runs.
-          const benchmarkCount = benchmarkSummary.benchmarkCount ?? 1;
-          const confidence = Math.min(1, benchmarkCount / RELIABLE_BENCHMARK_COUNT);
+          const benchmarkCount = taskCategorySignal?.seeded ? 1 : (benchmarkSummary.benchmarkCount ?? 1);
+          const confidence = Math.min(1, benchmarkCount / config.reliableBenchmarkCount);
           const heuristicScore = computeLocalModelHeuristicScore(model.id, complexity);
 
           score = empiricalScore * confidence + heuristicScore * (1 - confidence);
@@ -169,7 +180,7 @@ export const modelSelector = {
           logger.debug(
             `Local model ${model.id} has benchmark data: ` +
             `success=${successRate.toFixed(2)}, ` +
-            `quality=${qualitySignal.toFixed(2)}${taskCategoryScore !== undefined ? ` (task:${taskCategory})` : ''}, ` +
+            `quality=${qualitySignal.toFixed(2)}${taskCategoryScore !== undefined ? ` (task:${taskCategory}${taskCategorySignal?.seeded ? ':seeded' : ''})` : ''}, ` +
             `time=${avgResponseTime.toFixed(0)}ms, runs=${benchmarkCount}, ` +
             `confidence=${confidence.toFixed(2)}, score=${score.toFixed(2)}`,
           );

--- a/test/config/startup-benchmark-defaults.test.ts
+++ b/test/config/startup-benchmark-defaults.test.ts
@@ -16,6 +16,9 @@ import { randomUUID } from 'crypto';
 const originalRootDir = process.env.LOCALLAMA_ROOT_DIR;
 const originalStartupTargets = process.env.STARTUP_BENCHMARK_TARGETS;
 const originalFreshnessHours = process.env.BENCHMARK_FRESHNESS_HOURS;
+const originalReliableBenchmarkCount = process.env.RELIABLE_BENCHMARK_COUNT;
+const originalMinValidatorScore = process.env.MIN_VALIDATOR_SCORE;
+const originalValidationRetryBudget = process.env.VALIDATION_RETRY_BUDGET;
 
 function importFreshConfigModule(cacheKey: string) {
   const modulePath = path.resolve(process.cwd(), 'dist/config/index.js');
@@ -45,6 +48,9 @@ beforeAll(async () => {
   // Delete env vars that could bleed into config at module init time
   delete process.env.STARTUP_BENCHMARK_TARGETS;
   delete process.env.BENCHMARK_FRESHNESS_HOURS;
+  delete process.env.RELIABLE_BENCHMARK_COUNT;
+  delete process.env.MIN_VALIDATOR_SCORE;
+  delete process.env.VALIDATION_RETRY_BUDGET;
   configModule = await importFreshConfigModule(`startup-cfg-${randomUUID()}`);
 });
 
@@ -53,6 +59,9 @@ afterAll(() => {
   restoreEnv('LOCALLAMA_ROOT_DIR', originalRootDir);
   restoreEnv('STARTUP_BENCHMARK_TARGETS', originalStartupTargets);
   restoreEnv('BENCHMARK_FRESHNESS_HOURS', originalFreshnessHours);
+  restoreEnv('RELIABLE_BENCHMARK_COUNT', originalReliableBenchmarkCount);
+  restoreEnv('MIN_VALIDATOR_SCORE', originalMinValidatorScore);
+  restoreEnv('VALIDATION_RETRY_BUDGET', originalValidationRetryBudget);
 });
 
 // Helper: write a .env with base content plus extra lines and trigger a reload.
@@ -62,7 +71,18 @@ function reloadWith(extraLines: string[]) {
   // Align process.env with what we wrote so values not in .env are controlled
   delete process.env.STARTUP_BENCHMARK_TARGETS;
   delete process.env.BENCHMARK_FRESHNESS_HOURS;
-  return configModule.reloadConfig() as { activeConfig: { startupBenchmarkTargets: string[]; benchmarkFreshnessHours: number } };
+  delete process.env.RELIABLE_BENCHMARK_COUNT;
+  delete process.env.MIN_VALIDATOR_SCORE;
+  delete process.env.VALIDATION_RETRY_BUDGET;
+  return configModule.reloadConfig() as {
+    activeConfig: {
+      startupBenchmarkTargets: string[];
+      benchmarkFreshnessHours: number;
+      reliableBenchmarkCount: number;
+      minValidatorScore: number;
+      validationRetryBudget: number;
+    };
+  };
 }
 
 describe('startupBenchmarkTargets default', () => {
@@ -89,6 +109,28 @@ describe('startupBenchmarkTargets default', () => {
   it('honours STARTUP_BENCHMARK_TARGETS=local,free', () => {
     const result = reloadWith(['STARTUP_BENCHMARK_TARGETS=local,free']);
     expect(result.activeConfig.startupBenchmarkTargets).toEqual(['local', 'free']);
+  });
+});
+
+describe('validation scoring config gates', () => {
+  it('defaults shared validation gates when absent from .env', () => {
+    const result = reloadWith([]);
+
+    expect(result.activeConfig.reliableBenchmarkCount).toBe(3);
+    expect(result.activeConfig.minValidatorScore).toBe(0.6);
+    expect(result.activeConfig.validationRetryBudget).toBe(1);
+  });
+
+  it('reads shared validation gates from .env', () => {
+    const result = reloadWith([
+      'RELIABLE_BENCHMARK_COUNT=5',
+      'MIN_VALIDATOR_SCORE=0.75',
+      'VALIDATION_RETRY_BUDGET=2',
+    ]);
+
+    expect(result.activeConfig.reliableBenchmarkCount).toBe(5);
+    expect(result.activeConfig.minValidatorScore).toBe(0.75);
+    expect(result.activeConfig.validationRetryBudget).toBe(2);
   });
 });
 

--- a/test/modules/api-integration/routing/index.test.ts
+++ b/test/modules/api-integration/routing/index.test.ts
@@ -14,6 +14,7 @@ jest.unstable_mockModule('../../../../dist/config/index.js', () => ({
     openRouterApiKey: 'test-key',
     openRouterFreeOnly: false,
     costThreshold: 0.02,
+    reliableBenchmarkCount: 3,
     providerMaxConcurrentLocal: 1,
     cacheDir: 'test-cache',
   },

--- a/test/modules/benchmark/model-benchmarker.test.ts
+++ b/test/modules/benchmark/model-benchmarker.test.ts
@@ -227,6 +227,20 @@ describe('benchmarkModel', () => {
     expect(typeof result.summary.scores.code).toBe('number');
   });
 
+  it('populates summary.scores.validate from validate category quality', async () => {
+    const result = await benchmarkModel({ modelId: 'qwen2.5-coder-7b', taskCategories: ['validate'] });
+
+    expect(result.categoryResults.validate?.tasksRan).toBeGreaterThan(0);
+    expect(typeof result.summary.scores.validate).toBe('number');
+    expect(updateBenchmarkSummaryMock).toHaveBeenCalledWith(
+      'qwen2.5-coder-7b',
+      expect.objectContaining({
+        taskCategories: ['validate'],
+        scores: expect.objectContaining({ validate: expect.any(Number) }),
+      }),
+    );
+  });
+
   it('falls back to scanning providers when model is not in ModelRegistry', async () => {
     modelRegistryMock.getModel.mockReturnValue(undefined);
     supportsModelMock.mockReturnValue(true); // provider claims to support it

--- a/test/modules/decision-engine/modelSelector.task-category.test.ts
+++ b/test/modules/decision-engine/modelSelector.task-category.test.ts
@@ -21,7 +21,15 @@ jest.unstable_mockModule('../../../dist/modules/decision-engine/services/modelsD
   },
 }));
 
-const mockGetModel = jest.fn<(modelId: string) => { benchmarkSummary?: { scores?: { code?: number } } } | undefined>(() => undefined);
+const mockGetModel = jest.fn<(modelId: string) => {
+  benchmarkSummary?: {
+    scores?: { code?: number; validate?: number };
+    successRate?: number;
+    qualityScore?: number;
+    avgResponseTime?: number;
+    benchmarkCount?: number;
+  };
+} | undefined>(() => undefined);
 jest.unstable_mockModule('../../../dist/modules/core/model/index.js', () => ({
   getModelRegistry: () => ({
     getModel: mockGetModel,
@@ -114,6 +122,42 @@ describe('modelSelector.getBestLocalModel task-category scoring (issue #50)', ()
     mockGetModel.mockReturnValue(undefined);
 
     const selected = await modelSelector.getBestLocalModel(0.5, 500, undefined, 'code');
+    expect(selected?.id).toBe('model-a');
+  });
+
+  it('seeds validate score from code score with sparse confidence when no real validate run exists', async () => {
+    mockGetAvailableModels.mockResolvedValue([
+      { id: 'model-a', provider: 'ollama', contextWindow: 8192 },
+      { id: 'model-b', provider: 'ollama', contextWindow: 8192 },
+    ]);
+
+    mockGetModel.mockImplementation((id: string) => {
+      if (id === 'model-a') {
+        return {
+          benchmarkSummary: {
+            scores: { validate: 0.4 },
+            successRate: 1,
+            qualityScore: 0.4,
+            avgResponseTime: 1000,
+            benchmarkCount: 3,
+          },
+        };
+      }
+      if (id === 'model-b') {
+        return {
+          benchmarkSummary: {
+            scores: { code: 0.9 },
+            successRate: 1,
+            qualityScore: 0.9,
+            avgResponseTime: 1000,
+            benchmarkCount: 3,
+          },
+        };
+      }
+      return undefined;
+    });
+
+    const selected = await modelSelector.getBestLocalModel(0.5, 500, undefined, 'validate');
     expect(selected?.id).toBe('model-a');
   });
 });


### PR DESCRIPTION
## What changed

- Added `validate` as a first-class `benchmark_model` task category and MCP schema option.
- Added binary YES/NO validation fixtures that populate `summary.scores.validate`.
- Added seeded validation-score behavior from `scores.code * 0.8`, confidence-discounted as one benchmark run when real validate scores are absent.
- Exposed `RELIABLE_BENCHMARK_COUNT`, `MIN_VALIDATOR_SCORE`, and `VALIDATION_RETRY_BUDGET` config gates with documented defaults.

## Why

Closes #112 by adding the validation scoring primitives and shared reliability configuration needed for future validator selection and retry policy work.

## Validation

- `npm test -- --runTestsByPath test/modules/benchmark/model-benchmarker.test.ts test/config/startup-benchmark-defaults.test.ts test/modules/decision-engine/modelSelector.task-category.test.ts`
- `npm test` (61 suites / 464 tests; Jest still prints the existing forced-worker-exit warning after completion)