### PR TITLE
feat(validation): add OutputValidator module

### DIFF
--- a/src/modules/decision-engine/services/modelsDb.ts
+++ b/src/modules/decision-engine/services/modelsDb.ts
@@ -12,7 +12,7 @@ function toBenchmarkSummary(data: ModelPerformanceData): BenchmarkSummary {
   return {
     lastRunAt: data.lastBenchmarked ? new Date(data.lastBenchmarked).getTime() : Date.now(),
     taskCategories: [],
-    scores: {},
+    scores: data.scores || {},
     successRate: data.successRate,
     qualityScore: data.qualityScore,
     avgResponseTime: data.avgResponseTime,

--- a/src/modules/decision-engine/services/outputValidator.ts
+++ b/src/modules/decision-engine/services/outputValidator.ts
@@ -1,21 +1,26 @@
 import { getProviderRegistry } from '../../core/provider/index.js';
 import { getModelRegistry } from '../../core/model/index.js';
-import type { ModelMetadata } from '../../core/model/types.js';
 import { logger } from '../../../utils/logger.js';
 import { modelsDbService } from './modelsDb.js';
 
-function findFirstOccurrence(text: string, keywords: string[]): number {
-  let minIndex = -1;
-  for (const keyword of keywords) {
-    const regex = new RegExp(`\\b${keyword}\\b`, 'i');
-    const match = text.match(regex);
-    if (match && match.index !== undefined) {
-      if (minIndex === -1 || match.index < minIndex) {
-        minIndex = match.index;
-      }
-    }
+function parseProseVerdict(trimmed: string): { passed: boolean | null; parsedCleanly: boolean } {
+  const lowerOutput = trimmed.toLowerCase();
+  
+  // Negation pattern, e.g. "not correct", "never pass", "fails to be correct", "doesn't pass"
+  const negationRegex = /\b(not|never|no|n't|incorrect|fails?|without)\b\s+(?:[a-z]+\s+)?\b(pass|passes|passing|correct|yes)\b/i;
+  
+  // Word boundary checks for positive and negative keywords with inflections
+  const hasYes = /\b(pass|passes|passing|correct|yes)\b/i.test(lowerOutput);
+  const hasNo = /\b(fail|fails|failed|incorrect|no)\b/i.test(lowerOutput);
+  const hasNegatedYes = negationRegex.test(lowerOutput);
+
+  if (hasYes && !hasNegatedYes && !hasNo) {
+    return { passed: true, parsedCleanly: false };
+  } else if (hasNo || hasNegatedYes) {
+    return { passed: false, parsedCleanly: false };
   }
-  return minIndex;
+  
+  return { passed: null, parsedCleanly: false };
 }
 
 function calculateConfidence(explanation: string): number {
@@ -53,96 +58,22 @@ function calculateConfidence(explanation: string): number {
   return parseFloat(Math.max(0, Math.min(1, conf)).toFixed(2));
 }
 
-async function updateValidatorReputation(modelId: string, parsedCleanly: boolean): Promise<void> {
-  const registry = getModelRegistry();
-  const modelMetadata = registry.getModel(modelId);
-  
-  let oldScore = 0.5;
-  
-  if (modelMetadata?.capabilities?.scores?.validate !== undefined) {
-    oldScore = modelMetadata.capabilities.scores.validate;
-  } else if (modelMetadata?.benchmarkSummary?.scores?.validate !== undefined) {
-    oldScore = modelMetadata.benchmarkSummary.scores.validate;
-  } else if (modelMetadata?.capabilities?.scores?.code !== undefined) {
-    oldScore = modelMetadata.capabilities.scores.code * 0.8;
-  } else if (modelMetadata?.benchmarkSummary?.scores?.code !== undefined) {
-    oldScore = modelMetadata.benchmarkSummary.scores.code * 0.8;
-  } else if (modelMetadata?.benchmarkSummary?.qualityScore !== undefined) {
-    oldScore = modelMetadata.benchmarkSummary.qualityScore * 0.8;
-  }
-
-  const signal = parsedCleanly ? 1.0 : 0.0;
-  const newScore = oldScore * 0.95 + signal * 0.05;
-  
-  logger.debug(`[OutputValidator] Updating validator reputation for ${modelId}: old=${oldScore.toFixed(4)}, signal=${signal}, new=${newScore.toFixed(4)}`);
-  
-  if (modelMetadata) {
-    const currentSummary = modelMetadata.benchmarkSummary || {
-      lastRunAt: Date.now(),
-      taskCategories: [],
-      scores: {},
-      benchmarkCount: 0
-    };
-    const currentScores = currentSummary.scores || {};
-    const updatedSummary = {
-      ...currentSummary,
-      lastRunAt: Date.now(),
-      scores: {
-        ...currentScores,
-        validate: newScore
-      },
-      benchmarkCount: (currentSummary.benchmarkCount || 0) + 1
-    };
-    registry.updateBenchmarkSummary(modelId, updatedSummary);
-  }
-  
-  try {
-    const modelsDb = modelsDbService.getDatabase();
-    const existingDbModel = modelsDb.models[modelId];
-    if (existingDbModel) {
-      const dbScores = existingDbModel.scores || {};
-      const updatedScores = {
-        ...dbScores,
-        validate: newScore
-      };
-      
-      await modelsDbService.updateModelData(modelId, {
-        scores: updatedScores,
-        benchmarkCount: (existingDbModel.benchmarkCount || 0) + 1,
-        lastBenchmarked: new Date().toISOString()
-      });
-    } else {
-      await modelsDbService.updateModelData(modelId, {
-        id: modelId,
-        name: modelId,
-        provider: modelId.split('-')[0] || 'unknown',
-        lastSeen: new Date().toISOString(),
-        contextWindow: modelMetadata?.contextWindow || 4096,
-        successRate: modelMetadata?.benchmarkSummary?.successRate || 1.0,
-        qualityScore: modelMetadata?.benchmarkSummary?.qualityScore || 0.5,
-        avgResponseTime: modelMetadata?.benchmarkSummary?.avgResponseTime || 1000,
-        complexityScore: 0.5,
-        lastBenchmarked: new Date().toISOString(),
-        benchmarkCount: 1,
-        isFree: true,
-        scores: { validate: newScore }
-      });
-    }
-  } catch (error) {
-    logger.error(`[OutputValidator] Failed to update model db validation score for ${modelId}:`, error);
-  }
-}
-
 export class OutputValidator {
+  /**
+   * Validates generated output against a task.
+   * Completely decoupled from registry/DB side-effects for testability.
+   */
   static async validate(
     task: string,
     output: string,
-    validatorModel: ModelMetadata
+    provider: { executeTask: (modelId: string, prompt: string, options?: any) => Promise<{ content: string }> },
+    modelId: string
   ): Promise<{
-    passed: boolean;
+    passed: boolean | null;
     confidence: number;
     reason: string;
     parsed_cleanly: boolean;
+    skipped: boolean;
   }> {
     const prompt = [
       "Does this output correctly and completely satisfy the task? Answer only YES or NO on the first line, then explain.",
@@ -150,24 +81,30 @@ export class OutputValidator {
       `Output: ${output}`
     ].join('\n\n');
 
-    let passed = true;
+    let passed: boolean | null = null;
     let parsedCleanly = true;
     let confidence = 1.0;
     let reason = '';
+    let skipped = false;
 
     try {
-      const providerRegistry = getProviderRegistry();
-      const provider = providerRegistry.get(validatorModel.providerId);
-      if (!provider) {
-        throw new Error(`Provider not found: ${validatorModel.providerId}`);
-      }
-
-      const execResult = await provider.executeTask(validatorModel.id, prompt, {
+      const execResult = await provider.executeTask(modelId, prompt, {
         temperature: 0.1,
         maxTokens: 500
       });
 
       const trimmed = execResult.content.trim();
+      
+      if (!trimmed) {
+        return {
+          passed: null,
+          confidence: 0,
+          reason: 'Empty response from validator model',
+          parsed_cleanly: false,
+          skipped: true
+        };
+      }
+
       const lines = trimmed.split(/\r?\n/);
       const firstLine = lines[0].trim().toUpperCase();
 
@@ -180,41 +117,119 @@ export class OutputValidator {
         reason = lines.slice(1).join('\n').trim() || 'Failed validation';
         confidence = calculateConfidence(reason);
       } else {
-        parsedCleanly = false;
-        const lowerOutput = trimmed.toLowerCase();
-        const yesIndex = findFirstOccurrence(lowerOutput, ['pass', 'correct', 'yes']);
-        const noIndex = findFirstOccurrence(lowerOutput, ['fail', 'incorrect', 'no']);
-
-        if (yesIndex !== -1 && (noIndex === -1 || yesIndex < noIndex)) {
-          passed = true;
+        // Keyword fallback matching
+        const fallback = parseProseVerdict(trimmed);
+        passed = fallback.passed;
+        parsedCleanly = fallback.parsedCleanly;
+        
+        if (passed !== null) {
           reason = trimmed;
-          confidence = calculateConfidence(trimmed) * 0.8;
-        } else if (noIndex !== -1 && (yesIndex === -1 || noIndex < yesIndex)) {
-          passed = false;
-          reason = trimmed;
-          confidence = calculateConfidence(trimmed) * 0.8;
+          confidence = 0.5; // pinned confidence for keyword fallback
         } else {
-          passed = true; // graceful skip
+          skipped = true;
           reason = 'Unparseable response: ' + (trimmed.substring(0, 100) || '(empty)');
           confidence = 0;
         }
       }
     } catch (error) {
       parsedCleanly = false;
-      passed = true; // graceful skip on provider error
+      passed = null;
+      skipped = true;
       reason = `Provider error: ${error instanceof Error ? error.message : String(error)}`;
       confidence = 0;
       logger.error(`[OutputValidator] Error during validation execution:`, error);
     }
 
-    // Update EMA reputation
-    await updateValidatorReputation(validatorModel.id, parsedCleanly);
-
     return {
       passed,
       confidence,
       reason,
-      parsed_cleanly: parsedCleanly
+      parsed_cleanly: parsedCleanly,
+      skipped
     };
+  }
+
+  /**
+   * Updates validator model reputation via EMA.
+   * Promoted as an explicit side-effect method to avoid hidden side effects inside validate().
+   */
+  static async updateReputation(modelId: string, parsedCleanly: boolean): Promise<void> {
+    const registry = getModelRegistry();
+    const modelMetadata = registry.getModel(modelId);
+    
+    let oldScore = 0.5;
+    
+    if (modelMetadata?.capabilities?.scores?.validate !== undefined) {
+      oldScore = modelMetadata.capabilities.scores.validate;
+    } else if (modelMetadata?.benchmarkSummary?.scores?.validate !== undefined) {
+      oldScore = modelMetadata.benchmarkSummary.scores.validate;
+    } else if (modelMetadata?.capabilities?.scores?.code !== undefined) {
+      oldScore = modelMetadata.capabilities.scores.code * 0.8;
+    } else if (modelMetadata?.benchmarkSummary?.scores?.code !== undefined) {
+      oldScore = modelMetadata.benchmarkSummary.scores.code * 0.8;
+    } else if (modelMetadata?.benchmarkSummary?.qualityScore !== undefined) {
+      oldScore = modelMetadata.benchmarkSummary.qualityScore * 0.8;
+    }
+
+    const signal = parsedCleanly ? 1.0 : 0.0;
+    const newScore = oldScore * 0.95 + signal * 0.05;
+    
+    logger.debug(`[OutputValidator] Updating validator reputation for ${modelId}: old=${oldScore.toFixed(4)}, signal=${signal}, new=${newScore.toFixed(4)}`);
+    
+    if (modelMetadata) {
+      const currentSummary = modelMetadata.benchmarkSummary || {
+        lastRunAt: Date.now(),
+        taskCategories: [],
+        scores: {},
+        benchmarkCount: 0
+      };
+      const currentScores = currentSummary.scores || {};
+      const updatedSummary = {
+        ...currentSummary,
+        lastRunAt: Date.now(),
+        scores: {
+          ...currentScores,
+          validate: newScore
+        },
+        benchmarkCount: (currentSummary.benchmarkCount || 0) + 1
+      };
+      registry.updateBenchmarkSummary(modelId, updatedSummary);
+    }
+    
+    try {
+      const modelsDb = modelsDbService.getDatabase();
+      const existingDbModel = modelsDb.models[modelId];
+      if (existingDbModel) {
+        const dbScores = existingDbModel.scores || {};
+        const updatedScores = {
+          ...dbScores,
+          validate: newScore
+        };
+        
+        await modelsDbService.updateModelData(modelId, {
+          scores: updatedScores,
+          benchmarkCount: (existingDbModel.benchmarkCount || 0) + 1,
+          lastBenchmarked: new Date().toISOString()
+        });
+      } else {
+        await modelsDbService.updateModelData(modelId, {
+          id: modelId,
+          name: modelId,
+          provider: modelId.split('-')[0] || 'unknown',
+          lastSeen: new Date().toISOString(),
+          contextWindow: modelMetadata?.contextWindow || 4096,
+          successRate: modelMetadata?.benchmarkSummary?.successRate || 1.0,
+          qualityScore: modelMetadata?.benchmarkSummary?.qualityScore || 0.5,
+          avgResponseTime: modelMetadata?.benchmarkSummary?.avgResponseTime || 1000,
+          complexityScore: 0.5,
+          lastBenchmarked: new Date().toISOString(),
+          benchmarkCount: 1,
+          isFree: true,
+          scores: { validate: newScore }
+        });
+      }
+    } catch (error) {
+      logger.error(`[OutputValidator] Failed to update model db validation score for ${modelId}:`, error);
+    }
   }
 }

--- a/src/modules/decision-engine/services/outputValidator.ts
+++ b/src/modules/decision-engine/services/outputValidator.ts
@@ -1,0 +1,220 @@
+import { getProviderRegistry } from '../../core/provider/index.js';
+import { getModelRegistry } from '../../core/model/index.js';
+import type { ModelMetadata } from '../../core/model/types.js';
+import { logger } from '../../../utils/logger.js';
+import { modelsDbService } from './modelsDb.js';
+
+function findFirstOccurrence(text: string, keywords: string[]): number {
+  let minIndex = -1;
+  for (const keyword of keywords) {
+    const regex = new RegExp(`\\b${keyword}\\b`, 'i');
+    const match = text.match(regex);
+    if (match && match.index !== undefined) {
+      if (minIndex === -1 || match.index < minIndex) {
+        minIndex = match.index;
+      }
+    }
+  }
+  return minIndex;
+}
+
+function calculateConfidence(explanation: string): number {
+  const cleanExp = explanation.toLowerCase();
+  let conf = 0.8; // base confidence
+  
+  if (cleanExp.length < 15) {
+    conf -= 0.15;
+  } else if (cleanExp.length > 80) {
+    conf += 0.1;
+  }
+  
+  const uncertaintyWords = [
+    'maybe', 'probably', 'perhaps', 'unclear', 'not sure', 
+    'likely', 'possibly', 'depends', 'difficult to tell'
+  ];
+  for (const word of uncertaintyWords) {
+    if (cleanExp.includes(word)) {
+      conf -= 0.2;
+      break;
+    }
+  }
+  
+  const certaintyWords = [
+    'definitely', 'absolutely', 'clearly', 'incorrect', 'correct',
+    'perfectly', 'fail', 'passes', 'does not'
+  ];
+  for (const word of certaintyWords) {
+    if (cleanExp.includes(word)) {
+      conf += 0.05;
+      break;
+    }
+  }
+
+  return parseFloat(Math.max(0, Math.min(1, conf)).toFixed(2));
+}
+
+async function updateValidatorReputation(modelId: string, parsedCleanly: boolean): Promise<void> {
+  const registry = getModelRegistry();
+  const modelMetadata = registry.getModel(modelId);
+  
+  let oldScore = 0.5;
+  
+  if (modelMetadata?.capabilities?.scores?.validate !== undefined) {
+    oldScore = modelMetadata.capabilities.scores.validate;
+  } else if (modelMetadata?.benchmarkSummary?.scores?.validate !== undefined) {
+    oldScore = modelMetadata.benchmarkSummary.scores.validate;
+  } else if (modelMetadata?.capabilities?.scores?.code !== undefined) {
+    oldScore = modelMetadata.capabilities.scores.code * 0.8;
+  } else if (modelMetadata?.benchmarkSummary?.scores?.code !== undefined) {
+    oldScore = modelMetadata.benchmarkSummary.scores.code * 0.8;
+  } else if (modelMetadata?.benchmarkSummary?.qualityScore !== undefined) {
+    oldScore = modelMetadata.benchmarkSummary.qualityScore * 0.8;
+  }
+
+  const signal = parsedCleanly ? 1.0 : 0.0;
+  const newScore = oldScore * 0.95 + signal * 0.05;
+  
+  logger.debug(`[OutputValidator] Updating validator reputation for ${modelId}: old=${oldScore.toFixed(4)}, signal=${signal}, new=${newScore.toFixed(4)}`);
+  
+  if (modelMetadata) {
+    const currentSummary = modelMetadata.benchmarkSummary || {
+      lastRunAt: Date.now(),
+      taskCategories: [],
+      scores: {},
+      benchmarkCount: 0
+    };
+    const currentScores = currentSummary.scores || {};
+    const updatedSummary = {
+      ...currentSummary,
+      lastRunAt: Date.now(),
+      scores: {
+        ...currentScores,
+        validate: newScore
+      },
+      benchmarkCount: (currentSummary.benchmarkCount || 0) + 1
+    };
+    registry.updateBenchmarkSummary(modelId, updatedSummary);
+  }
+  
+  try {
+    const modelsDb = modelsDbService.getDatabase();
+    const existingDbModel = modelsDb.models[modelId];
+    if (existingDbModel) {
+      const dbScores = existingDbModel.scores || {};
+      const updatedScores = {
+        ...dbScores,
+        validate: newScore
+      };
+      
+      await modelsDbService.updateModelData(modelId, {
+        scores: updatedScores,
+        benchmarkCount: (existingDbModel.benchmarkCount || 0) + 1,
+        lastBenchmarked: new Date().toISOString()
+      });
+    } else {
+      await modelsDbService.updateModelData(modelId, {
+        id: modelId,
+        name: modelId,
+        provider: modelId.split('-')[0] || 'unknown',
+        lastSeen: new Date().toISOString(),
+        contextWindow: modelMetadata?.contextWindow || 4096,
+        successRate: modelMetadata?.benchmarkSummary?.successRate || 1.0,
+        qualityScore: modelMetadata?.benchmarkSummary?.qualityScore || 0.5,
+        avgResponseTime: modelMetadata?.benchmarkSummary?.avgResponseTime || 1000,
+        complexityScore: 0.5,
+        lastBenchmarked: new Date().toISOString(),
+        benchmarkCount: 1,
+        isFree: true,
+        scores: { validate: newScore }
+      });
+    }
+  } catch (error) {
+    logger.error(`[OutputValidator] Failed to update model db validation score for ${modelId}:`, error);
+  }
+}
+
+export class OutputValidator {
+  static async validate(
+    task: string,
+    output: string,
+    validatorModel: ModelMetadata
+  ): Promise<{
+    passed: boolean;
+    confidence: number;
+    reason: string;
+    parsed_cleanly: boolean;
+  }> {
+    const prompt = [
+      "Does this output correctly and completely satisfy the task? Answer only YES or NO on the first line, then explain.",
+      `Task: ${task}`,
+      `Output: ${output}`
+    ].join('\n\n');
+
+    let passed = true;
+    let parsedCleanly = true;
+    let confidence = 1.0;
+    let reason = '';
+
+    try {
+      const providerRegistry = getProviderRegistry();
+      const provider = providerRegistry.get(validatorModel.providerId);
+      if (!provider) {
+        throw new Error(`Provider not found: ${validatorModel.providerId}`);
+      }
+
+      const execResult = await provider.executeTask(validatorModel.id, prompt, {
+        temperature: 0.1,
+        maxTokens: 500
+      });
+
+      const trimmed = execResult.content.trim();
+      const lines = trimmed.split(/\r?\n/);
+      const firstLine = lines[0].trim().toUpperCase();
+
+      if (firstLine.startsWith('YES')) {
+        passed = true;
+        reason = lines.slice(1).join('\n').trim() || 'Passed validation';
+        confidence = calculateConfidence(reason);
+      } else if (firstLine.startsWith('NO')) {
+        passed = false;
+        reason = lines.slice(1).join('\n').trim() || 'Failed validation';
+        confidence = calculateConfidence(reason);
+      } else {
+        parsedCleanly = false;
+        const lowerOutput = trimmed.toLowerCase();
+        const yesIndex = findFirstOccurrence(lowerOutput, ['pass', 'correct', 'yes']);
+        const noIndex = findFirstOccurrence(lowerOutput, ['fail', 'incorrect', 'no']);
+
+        if (yesIndex !== -1 && (noIndex === -1 || yesIndex < noIndex)) {
+          passed = true;
+          reason = trimmed;
+          confidence = calculateConfidence(trimmed) * 0.8;
+        } else if (noIndex !== -1 && (yesIndex === -1 || noIndex < yesIndex)) {
+          passed = false;
+          reason = trimmed;
+          confidence = calculateConfidence(trimmed) * 0.8;
+        } else {
+          passed = true; // graceful skip
+          reason = 'Unparseable response: ' + (trimmed.substring(0, 100) || '(empty)');
+          confidence = 0;
+        }
+      }
+    } catch (error) {
+      parsedCleanly = false;
+      passed = true; // graceful skip on provider error
+      reason = `Provider error: ${error instanceof Error ? error.message : String(error)}`;
+      confidence = 0;
+      logger.error(`[OutputValidator] Error during validation execution:`, error);
+    }
+
+    // Update EMA reputation
+    await updateValidatorReputation(validatorModel.id, parsedCleanly);
+
+    return {
+      passed,
+      confidence,
+      reason,
+      parsed_cleanly: parsedCleanly
+    };
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -274,6 +274,12 @@ export interface ModelPerformanceData {
   lastBenchmarked: string;
   benchmarkCount: number;
   isFree: boolean; // Whether this is a free model
+  scores?: {
+    code?: number;
+    reasoning?: number;
+    speed?: number;
+    validate?: number;
+  };
   tokenEfficiency?: number;
   systemResourceUsage?: number;
   memoryFootprint?: number;

--- a/test/modules/decision-engine/outputValidator.test.ts
+++ b/test/modules/decision-engine/outputValidator.test.ts
@@ -1,16 +1,7 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import type { ModelMetadata } from '../../../dist/modules/core/model/types.js';
 
 jest.unstable_mockModule('../../../dist/utils/logger.js', () => ({
   logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
-}));
-
-const mockExecuteTask = jest.fn();
-const mockGetProvider = jest.fn();
-jest.unstable_mockModule('../../../dist/modules/core/provider/index.js', () => ({
-  getProviderRegistry: () => ({
-    get: mockGetProvider,
-  }),
 }));
 
 const mockGetModel = jest.fn();
@@ -33,116 +24,140 @@ jest.unstable_mockModule('../../../dist/modules/decision-engine/services/modelsD
 
 const { OutputValidator } = await import('../../../dist/modules/decision-engine/services/outputValidator.js');
 
-describe('OutputValidator.validate test suite', () => {
-  const mockModel: ModelMetadata = {
-    id: 'test-model',
-    providerId: 'test-provider',
-    displayName: 'Test Model',
-    contextWindow: 4096,
-    capabilities: { chat: true, code: true, vision: false, toolUse: false, largeContext: false, maxContextTokens: 4096 },
-    cost: { prompt: 0, completion: 0 },
-    promptingStrategyId: 'default',
-  };
-
+describe('OutputValidator.validate (Unit Tests)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetDatabase.mockReturnValue({ models: {} });
   });
 
   it('verifies happy path with YES first line', async () => {
-    mockGetProvider.mockReturnValue({
-      id: 'test-provider',
-      executeTask: mockExecuteTask.mockResolvedValue({
+    const mockProvider = {
+      executeTask: jest.fn<any>().mockResolvedValue({
         content: 'YES\nThe code is perfectly correct and meets all requirements.',
       }),
-    });
+    };
 
-    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a+b; }', mockModel);
+    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a+b; }', mockProvider, 'test-model');
 
     expect(result.passed).toBe(true);
     expect(result.parsed_cleanly).toBe(true);
+    expect(result.skipped).toBe(false);
     expect(result.confidence).toBeGreaterThanOrEqual(0.8);
     expect(result.reason).toBe('The code is perfectly correct and meets all requirements.');
   });
 
   it('verifies path with NO first line', async () => {
-    mockGetProvider.mockReturnValue({
-      id: 'test-provider',
-      executeTask: mockExecuteTask.mockResolvedValue({
+    const mockProvider = {
+      executeTask: jest.fn<any>().mockResolvedValue({
         content: 'NO\nThe code has syntax errors and is missing return type.',
       }),
-    });
+    };
 
-    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a-b; }', mockModel);
+    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a-b; }', mockProvider, 'test-model');
 
     expect(result.passed).toBe(false);
     expect(result.parsed_cleanly).toBe(true);
+    expect(result.skipped).toBe(false);
     expect(result.confidence).toBeGreaterThanOrEqual(0.8);
     expect(result.reason).toBe('The code has syntax errors and is missing return type.');
   });
 
-  it('performs keyword fallback for YES in prose', async () => {
-    mockGetProvider.mockReturnValue({
-      id: 'test-provider',
-      executeTask: mockExecuteTask.mockResolvedValue({
-        content: 'This solution is correct because the add function is implemented correctly.',
+  it('performs keyword fallback for YES in prose with pinned confidence', async () => {
+    const mockProvider = {
+      executeTask: jest.fn<any>().mockResolvedValue({
+        content: 'This solution is correct.',
       }),
-    });
+    };
 
-    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a+b; }', mockModel);
+    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a+b; }', mockProvider, 'test-model');
 
     expect(result.passed).toBe(true);
     expect(result.parsed_cleanly).toBe(false);
-    expect(result.reason).toContain('correct');
+    expect(result.skipped).toBe(false);
+    expect(result.confidence).toBe(0.5); // pinned confidence
   });
 
-  it('performs keyword fallback for NO in prose', async () => {
-    mockGetProvider.mockReturnValue({
-      id: 'test-provider',
-      executeTask: mockExecuteTask.mockResolvedValue({
-        content: 'This solution is incorrect and fails the main unit test case.',
+  it('performs keyword fallback for NO in prose with pinned confidence', async () => {
+    const mockProvider = {
+      executeTask: jest.fn<any>().mockResolvedValue({
+        content: 'This solution fails the tests.',
       }),
-    });
+    };
 
-    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a-b; }', mockModel);
+    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a-b; }', mockProvider, 'test-model');
 
     expect(result.passed).toBe(false);
     expect(result.parsed_cleanly).toBe(false);
-    expect(result.reason).toContain('incorrect');
+    expect(result.skipped).toBe(false);
+    expect(result.confidence).toBe(0.5); // pinned confidence
   });
 
-  it('performs graceful skip on completely unparseable prose', async () => {
-    mockGetProvider.mockReturnValue({
-      id: 'test-provider',
-      executeTask: mockExecuteTask.mockResolvedValue({
-        content: 'I am a model and this is some completely neutral text that does not have keywords.',
+  it('handles negation trap: not correct', async () => {
+    const mockProvider = {
+      executeTask: jest.fn<any>().mockResolvedValue({
+        content: 'This output is not correct.',
       }),
-    });
+    };
 
-    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a+b; }', mockModel);
+    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a-b; }', mockProvider, 'test-model');
 
-    expect(result.passed).toBe(true);
+    expect(result.passed).toBe(false); // correctly identified negation
     expect(result.parsed_cleanly).toBe(false);
-    expect(result.confidence).toBe(0);
-    expect(result.reason).toContain('Unparseable response');
+    expect(result.skipped).toBe(false);
   });
 
-  it('degrades gracefully and returns true when provider throws error', async () => {
-    mockGetProvider.mockReturnValue({
-      id: 'test-provider',
-      executeTask: mockExecuteTask.mockRejectedValue(new Error('Connection failure')),
-    });
+  it('handles empty output gracefully', async () => {
+    const mockProvider = {
+      executeTask: jest.fn<any>().mockResolvedValue({
+        content: '   ',
+      }),
+    };
 
-    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a+b; }', mockModel);
+    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a+b; }', mockProvider, 'test-model');
 
-    expect(result.passed).toBe(true);
+    expect(result.passed).toBeNull();
     expect(result.parsed_cleanly).toBe(false);
+    expect(result.skipped).toBe(true);
     expect(result.confidence).toBe(0);
-    expect(result.reason).toContain('Provider error: Connection failure');
+    expect(result.reason).toContain('Empty response');
+  });
+
+  it('handles unparseable prose gracefully (skipped)', async () => {
+    const mockProvider = {
+      executeTask: jest.fn<any>().mockResolvedValue({
+        content: 'I am not sure what is happening here.',
+      }),
+    };
+
+    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a+b; }', mockProvider, 'test-model');
+
+    expect(result.passed).toBeNull(); // skipped
+    expect(result.parsed_cleanly).toBe(false);
+    expect(result.skipped).toBe(true);
+    expect(result.confidence).toBe(0);
+  });
+
+  it('handles provider throw gracefully (skipped)', async () => {
+    const mockProvider = {
+      executeTask: jest.fn<any>().mockRejectedValue(new Error('API failure')),
+    };
+
+    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a+b; }', mockProvider, 'test-model');
+
+    expect(result.passed).toBeNull();
+    expect(result.parsed_cleanly).toBe(false);
+    expect(result.skipped).toBe(true);
+    expect(result.confidence).toBe(0);
+    expect(result.reason).toContain('Provider error: API failure');
+  });
+});
+
+describe('OutputValidator.updateReputation (Integration / Decoupled Unit Test)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetDatabase.mockReturnValue({ models: {} });
   });
 
   it('updates validator model reputation in registry and db via EMA', async () => {
-    // 1. Initial setup: model has validate score of 0.8 in registry and db
     mockGetModel.mockReturnValue({
       id: 'test-model',
       benchmarkSummary: {
@@ -161,17 +176,8 @@ describe('OutputValidator.validate test suite', () => {
       },
     });
 
-    mockGetProvider.mockReturnValue({
-      id: 'test-provider',
-      executeTask: mockExecuteTask.mockResolvedValue({
-        content: 'YES\nThe code is correct.',
-      }),
-    });
+    await OutputValidator.updateReputation('test-model', true);
 
-    // 2. Execute validation (parsed_cleanly = true, signal = 1.0)
-    await OutputValidator.validate('task', 'output', mockModel);
-
-    // newScore = 0.8 * 0.95 + 1.0 * 0.05 = 0.76 + 0.05 = 0.81
     expect(mockUpdateBenchmarkSummary).toHaveBeenCalledWith(
       'test-model',
       expect.objectContaining({

--- a/test/modules/decision-engine/outputValidator.test.ts
+++ b/test/modules/decision-engine/outputValidator.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { ModelMetadata } from '../../../dist/modules/core/model/types.js';
+
+jest.unstable_mockModule('../../../dist/utils/logger.js', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const mockExecuteTask = jest.fn();
+const mockGetProvider = jest.fn();
+jest.unstable_mockModule('../../../dist/modules/core/provider/index.js', () => ({
+  getProviderRegistry: () => ({
+    get: mockGetProvider,
+  }),
+}));
+
+const mockGetModel = jest.fn();
+const mockUpdateBenchmarkSummary = jest.fn();
+jest.unstable_mockModule('../../../dist/modules/core/model/index.js', () => ({
+  getModelRegistry: () => ({
+    getModel: mockGetModel,
+    updateBenchmarkSummary: mockUpdateBenchmarkSummary,
+  }),
+}));
+
+const mockGetDatabase = jest.fn();
+const mockUpdateModelData = jest.fn();
+jest.unstable_mockModule('../../../dist/modules/decision-engine/services/modelsDb.js', () => ({
+  modelsDbService: {
+    getDatabase: mockGetDatabase,
+    updateModelData: mockUpdateModelData,
+  },
+}));
+
+const { OutputValidator } = await import('../../../dist/modules/decision-engine/services/outputValidator.js');
+
+describe('OutputValidator.validate test suite', () => {
+  const mockModel: ModelMetadata = {
+    id: 'test-model',
+    providerId: 'test-provider',
+    displayName: 'Test Model',
+    contextWindow: 4096,
+    capabilities: { chat: true, code: true, vision: false, toolUse: false, largeContext: false, maxContextTokens: 4096 },
+    cost: { prompt: 0, completion: 0 },
+    promptingStrategyId: 'default',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetDatabase.mockReturnValue({ models: {} });
+  });
+
+  it('verifies happy path with YES first line', async () => {
+    mockGetProvider.mockReturnValue({
+      id: 'test-provider',
+      executeTask: mockExecuteTask.mockResolvedValue({
+        content: 'YES\nThe code is perfectly correct and meets all requirements.',
+      }),
+    });
+
+    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a+b; }', mockModel);
+
+    expect(result.passed).toBe(true);
+    expect(result.parsed_cleanly).toBe(true);
+    expect(result.confidence).toBeGreaterThanOrEqual(0.8);
+    expect(result.reason).toBe('The code is perfectly correct and meets all requirements.');
+  });
+
+  it('verifies path with NO first line', async () => {
+    mockGetProvider.mockReturnValue({
+      id: 'test-provider',
+      executeTask: mockExecuteTask.mockResolvedValue({
+        content: 'NO\nThe code has syntax errors and is missing return type.',
+      }),
+    });
+
+    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a-b; }', mockModel);
+
+    expect(result.passed).toBe(false);
+    expect(result.parsed_cleanly).toBe(true);
+    expect(result.confidence).toBeGreaterThanOrEqual(0.8);
+    expect(result.reason).toBe('The code has syntax errors and is missing return type.');
+  });
+
+  it('performs keyword fallback for YES in prose', async () => {
+    mockGetProvider.mockReturnValue({
+      id: 'test-provider',
+      executeTask: mockExecuteTask.mockResolvedValue({
+        content: 'This solution is correct because the add function is implemented correctly.',
+      }),
+    });
+
+    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a+b; }', mockModel);
+
+    expect(result.passed).toBe(true);
+    expect(result.parsed_cleanly).toBe(false);
+    expect(result.reason).toContain('correct');
+  });
+
+  it('performs keyword fallback for NO in prose', async () => {
+    mockGetProvider.mockReturnValue({
+      id: 'test-provider',
+      executeTask: mockExecuteTask.mockResolvedValue({
+        content: 'This solution is incorrect and fails the main unit test case.',
+      }),
+    });
+
+    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a-b; }', mockModel);
+
+    expect(result.passed).toBe(false);
+    expect(result.parsed_cleanly).toBe(false);
+    expect(result.reason).toContain('incorrect');
+  });
+
+  it('performs graceful skip on completely unparseable prose', async () => {
+    mockGetProvider.mockReturnValue({
+      id: 'test-provider',
+      executeTask: mockExecuteTask.mockResolvedValue({
+        content: 'I am a model and this is some completely neutral text that does not have keywords.',
+      }),
+    });
+
+    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a+b; }', mockModel);
+
+    expect(result.passed).toBe(true);
+    expect(result.parsed_cleanly).toBe(false);
+    expect(result.confidence).toBe(0);
+    expect(result.reason).toContain('Unparseable response');
+  });
+
+  it('degrades gracefully and returns true when provider throws error', async () => {
+    mockGetProvider.mockReturnValue({
+      id: 'test-provider',
+      executeTask: mockExecuteTask.mockRejectedValue(new Error('Connection failure')),
+    });
+
+    const result = await OutputValidator.validate('write add function', 'function add(a,b) { return a+b; }', mockModel);
+
+    expect(result.passed).toBe(true);
+    expect(result.parsed_cleanly).toBe(false);
+    expect(result.confidence).toBe(0);
+    expect(result.reason).toContain('Provider error: Connection failure');
+  });
+
+  it('updates validator model reputation in registry and db via EMA', async () => {
+    // 1. Initial setup: model has validate score of 0.8 in registry and db
+    mockGetModel.mockReturnValue({
+      id: 'test-model',
+      benchmarkSummary: {
+        scores: { validate: 0.8 },
+        benchmarkCount: 2,
+      },
+    });
+
+    mockGetDatabase.mockReturnValue({
+      models: {
+        'test-model': {
+          id: 'test-model',
+          scores: { validate: 0.8 },
+          benchmarkCount: 2,
+        },
+      },
+    });
+
+    mockGetProvider.mockReturnValue({
+      id: 'test-provider',
+      executeTask: mockExecuteTask.mockResolvedValue({
+        content: 'YES\nThe code is correct.',
+      }),
+    });
+
+    // 2. Execute validation (parsed_cleanly = true, signal = 1.0)
+    await OutputValidator.validate('task', 'output', mockModel);
+
+    // newScore = 0.8 * 0.95 + 1.0 * 0.05 = 0.76 + 0.05 = 0.81
+    expect(mockUpdateBenchmarkSummary).toHaveBeenCalledWith(
+      'test-model',
+      expect.objectContaining({
+        scores: expect.objectContaining({ validate: 0.81 }),
+        benchmarkCount: 3,
+      }),
+    );
+
+    expect(mockUpdateModelData).toHaveBeenCalledWith(
+      'test-model',
+      expect.objectContaining({
+        scores: expect.objectContaining({ validate: 0.81 }),
+        benchmarkCount: 3,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Closes #113. Deliver isolated OutputValidator module with resilient parsing, keyword fallback, provider error handling, and EMA validator reputation updates. All tests pass.