### PR TITLE
fix(routing): local-first cost routing, llama.cpp port scan, provider field normalization

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -55,6 +55,7 @@ export interface Config {
   llamaCppHealthProbeEnabled: boolean;
   llamaCppHealthProbePrompt: string;
   llamaCppHealthProbeTimeoutMs: number;
+  llamaCppPortScanEnabled: boolean;
   /** Optional context window cap applied when building --ctx-size flag from GGUF metadata. */
   llamaCppMaxCtx?: number;
   /** Extra flags appended to recommended GGUF flags when spawning llama-server. */
@@ -255,6 +256,7 @@ function buildConfigFromEnv(env: NodeJS.ProcessEnv): Config {
     llamaCppHealthProbeEnabled: parseBool(env.LLAMA_CPP_HEALTH_PROBE_ENABLED, true),
     llamaCppHealthProbePrompt: env.LLAMA_CPP_HEALTH_PROBE_PROMPT || `write 'ok'`,
     llamaCppHealthProbeTimeoutMs: parseNumber(env.LLAMA_CPP_HEALTH_PROBE_TIMEOUT_MS, 10000, 1000),
+    llamaCppPortScanEnabled: parseBool(env.LLAMA_CPP_PORT_SCAN_ENABLED, true),
     llamaCppMaxCtx: env.LLAMA_CPP_MAX_CTX ? parseNumber(env.LLAMA_CPP_MAX_CTX, 0, 512) : undefined,
     llamaCppServerFlags: env.LLAMA_CPP_SERVER_FLAGS
       ? env.LLAMA_CPP_SERVER_FLAGS.trim().split(/\s+/).filter(Boolean)

--- a/src/modules/api-integration/routing/index.ts
+++ b/src/modules/api-integration/routing/index.ts
@@ -1052,11 +1052,10 @@ export class Router implements IRouter {
 
       if (forcedModelId && forcedProviderId) {
         const modelRegistry = getModelRegistry();
-        const forcedModel = modelRegistry.getModel(forcedModelId) || {
-          id: forcedModelId,
-          providerId: forcedProviderId,
-          contextWindow: 8192,
-        };
+        const _registryModel = modelRegistry.getModel(forcedModelId);
+        const forcedModel = _registryModel
+          ? { ..._registryModel, provider: _registryModel.providerId }
+          : { id: forcedModelId, provider: forcedProviderId, contextWindow: 8192 };
         for (const subtask of decomposedTask.subtasks) {
           modelAssignments.set(subtask.id, forcedModel as any);
         }

--- a/src/modules/decision-engine/index.ts
+++ b/src/modules/decision-engine/index.ts
@@ -317,12 +317,12 @@ export const decisionEngine = {
         explanation += 'Priority factor: Speed is prioritized, strongly favoring paid API. ';
         break;
       case 'cost':
-        localScore += 0.8 * factors.priority.weight;
+        localScore += 1.0 * factors.priority.weight;
         explanation += 'Priority factor: Cost is prioritized, strongly favoring local model. ';
-        
+
         if (hasFreeModels) {
-          freeScore += 0.9 * factors.priority.weight;
-          explanation += 'Free models also have zero cost and may be faster than local models. ';
+          freeScore += 0.8 * factors.priority.weight;
+          explanation += 'Free models also have zero cost and are used when local is unavailable. ';
         }
         break;
       case 'quality':
@@ -536,13 +536,12 @@ export const decisionEngine = {
         explanation += 'Priority factor: Speed is prioritized. ';
         break;
       case 'cost':
+        localScore += 0.6 * factors.priority.weight;
         if (hasFreeModels) {
-          freeScore += 0.5 * factors.priority.weight;
-        } else {
-          localScore += 0.4 * factors.priority.weight;
+          freeScore += 0.4 * factors.priority.weight;
         }
         factors.priority.wasFactor = true;
-        explanation += 'Priority factor: Cost is prioritized. ';
+        explanation += 'Priority factor: Cost is prioritized, preferring local then free. ';
         break;
       case 'quality':
         paidScore += 0.3 * factors.priority.weight;

--- a/src/modules/llama-cpp/index.ts
+++ b/src/modules/llama-cpp/index.ts
@@ -38,7 +38,10 @@ import { readGgufMetadata, GgufMetadata } from './gguf.js';
 
 function isDegenerate(text: string): boolean {
   if (!text || /^\s*$/.test(text)) return true; // empty or whitespace
-  if (text.toLowerCase().includes('thinking')) return true;
+  // Strip <think>...</think> blocks (Qwen3 and other reasoning models)
+  const stripped = text.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
+  const check = stripped || text; // fall back to full text if stripping leaves nothing
+  if (check.toLowerCase().includes('thinking')) return true;
 
   const uniqueChars = new Set(text);
   if (uniqueChars.size <= 2) {
@@ -160,6 +163,32 @@ export const llamaCppModule = {
         }
       } catch {
         logger.debug(`Existing llama.cpp endpoint ${config.llamaCppEndpoint} unreachable`);
+      }
+    }
+
+    // 2b. Port scan — find a running llama-server near the configured port
+    if (config.llamaCppPortScanEnabled !== false) {
+      const hintUrl = config.llamaCppEndpoint;
+      const hintPort = hintUrl
+        ? (() => { try { return parseInt(new URL(hintUrl).port, 10) || 8080; } catch { return config.llamaCppPort ?? 8190; } })()
+        : (config.llamaCppPort ?? 8190);
+      const SCAN_RANGE = 20;
+      for (let p = hintPort; p <= hintPort + SCAN_RANGE; p++) {
+        try {
+          const res = await axios.get(`http://localhost:${p}/health`, { timeout: 500 });
+          if (res.status === 200) {
+            const candidate = `http://localhost:${p}`;
+            (config as any).llamaCppEndpoint = candidate;
+            await this.refreshModels();
+            if (this.cachedModels.length > 0) {
+              logger.info(`llama.cpp: auto-detected running server at ${candidate}`);
+              await this._runHealthProbe();
+              return;
+            }
+          }
+        } catch {
+          // port not live — continue
+        }
       }
     }
 

--- a/test/modules/llama-cpp/managed-spawn.test.ts
+++ b/test/modules/llama-cpp/managed-spawn.test.ts
@@ -10,6 +10,7 @@ const configMock = {
   llamaCppServerBin: '',
   llamaCppModelPath: '/models/m.gguf',
   llamaCppHealthProbeEnabled: false,
+  llamaCppPortScanEnabled: false,
 };
 
 jest.unstable_mockModule('../../../dist/config/index.js', () => ({


### PR DESCRIPTION
## Summary

- **Local-first cost routing**: Flip priority scoring so local models beat free OpenRouter when `priority=cost` (local 1.0 > free 0.8 in preemptive path; 0.6 > 0.4 in full path). Previously free models always won, preventing local llama.cpp/Ollama from being used.
- **llama.cpp port scan**: On `initialize()`, scan ports `hintPort..hintPort+20` to auto-detect a running `llama-server` without requiring explicit `LLAMA_CPP_ENDPOINT`. Gated by `LLAMA_CPP_PORT_SCAN_ENABLED` env var (default `true`).
- **Fix `provider: undefined` in subtask execution**: `ModelMetadata.providerId` ≠ `Model.provider` — when pulling a forced model from the registry, normalize it with `provider: registryModel.providerId`; fallback object also fixed from `providerId` → `provider`.
- **Qwen3 `isDegenerate` fix**: Strip `<think>…</think>` blocks before checking for the word "thinking" so reasoning models don't false-positive.
- **Test fix**: Set `llamaCppPortScanEnabled: false` in managed-spawn test to prevent port scan from consuming mock axios calls before the managed spawn code path runs.

## Test plan

- [x] All 508 tests pass (`npm test`)
- [x] Real-world: `route_task` with `priority=cost` now routes to `local` (Ollama `llama3.2:3b`) instead of free OpenRouter
- [x] llama.cpp auto-detected at `:8190` after server restart without setting `LLAMA_CPP_ENDPOINT`
- [x] Subtask execution no longer errors with `provider: undefined`
- [x] Qwen3-8B output no longer flagged as degenerate due to `<think>` blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)